### PR TITLE
Implement Tone Editor Agent personalization (Issue #24)

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -2,11 +2,12 @@
 
 from .research import research_subagent, create_research_subagent
 from .topic_selector import topic_selection_agent
-from .tone_editor import tone_agent
+from .tone_editor import tone_agent, create_tone_editor_agent
 
 __all__ = [
     "research_subagent",
     "create_research_subagent",
     "topic_selection_agent",
     "tone_agent",
+    "create_tone_editor_agent",
 ]

--- a/src/agents/test_tone_editor.py
+++ b/src/agents/test_tone_editor.py
@@ -1,0 +1,353 @@
+"""Comprehensive tests for tone editor personalization."""
+
+import pytest
+from .tone_editor import (
+    build_personalized_tone_prompt,
+    create_tone_editor_agent,
+    tone_agent,
+)
+from ..config import TONE_EDITOR_PROMPT
+
+
+# =============================================================================
+# build_personalized_tone_prompt Tests
+# =============================================================================
+
+
+class TestBuildPersonalizedTonePrompt:
+    """Tests for prompt building with personalization."""
+
+    def test_no_personalization_returns_base_prompt(self):
+        """Test that no parameters returns base prompt unchanged."""
+        result = build_personalized_tone_prompt()
+        assert result == TONE_EDITOR_PROMPT
+
+    def test_difficulty_only(self):
+        """Test personalization with difficulty only."""
+        result = build_personalized_tone_prompt(difficulty="초급")
+        assert TONE_EDITOR_PROMPT in result
+        assert "난이도별 조정" in result
+        assert "초급" in result
+        assert "용어 설명 수준" in result
+
+    def test_duration_only(self):
+        """Test personalization with duration only."""
+        result = build_personalized_tone_prompt(duration="5분")
+        assert TONE_EDITOR_PROMPT in result
+        assert "분량별 조정" in result
+        assert "5분" in result
+        assert "섹션 상세도" in result
+
+    def test_both_difficulty_and_duration(self):
+        """Test personalization with both difficulty and duration."""
+        result = build_personalized_tone_prompt(difficulty="중급", duration="10분")
+        assert TONE_EDITOR_PROMPT in result
+        assert "난이도별 조정" in result
+        assert "분량별 조정" in result
+        assert "중급" in result
+        assert "10분" in result
+
+    def test_beginner_difficulty_includes_examples(self):
+        """Test beginner difficulty includes detailed examples."""
+        result = build_personalized_tone_prompt(difficulty="초급")
+        assert "모든 기술 용어를 상세히 설명" in result
+        assert "RAG(Retrieval-Augmented Generation" in result
+        assert "일상적인 비유를 많이 사용" in result
+
+    def test_intermediate_difficulty_includes_examples(self):
+        """Test intermediate difficulty includes balanced examples."""
+        result = build_personalized_tone_prompt(difficulty="중급")
+        assert "핵심 용어만 간단히 설명" in result
+        assert "RAG(검색 증강 생성)" in result
+        assert "실무 적용에 초점" in result
+
+    def test_advanced_difficulty_includes_examples(self):
+        """Test advanced difficulty includes minimal examples."""
+        result = build_personalized_tone_prompt(difficulty="고급")
+        assert "기술 용어 설명을 최소화" in result
+        assert "RAG 아키텍처에서 retriever" in result
+        assert "전문적인 내용에 집중" in result
+
+    def test_3min_duration_includes_guidance(self):
+        """Test 3min duration includes concise guidance."""
+        result = build_personalized_tone_prompt(duration="3분")
+        assert "핵심만 간결하게 전달" in result
+        assert "예시는 생략" in result
+
+    def test_5min_duration_includes_guidance(self):
+        """Test 5min duration includes balanced guidance."""
+        result = build_personalized_tone_prompt(duration="5분")
+        assert "균형잡힌 분량" in result
+        assert "중요한 예시 1개 정도" in result
+
+    def test_10min_duration_includes_guidance(self):
+        """Test 10min duration includes detailed guidance."""
+        result = build_personalized_tone_prompt(duration="10분")
+        assert "상세한 설명" in result
+        assert "예시 2개" in result
+        assert "코드 스니펫" in result
+
+    def test_15min_duration_includes_guidance(self):
+        """Test 15min+ duration includes comprehensive guidance."""
+        result = build_personalized_tone_prompt(duration="15분+")
+        assert "깊이 있는 분석" in result
+        assert "다양한 예시" in result
+        assert "종합적으로 설명" in result
+
+    def test_english_difficulty_inputs(self):
+        """Test English difficulty inputs are handled."""
+        result = build_personalized_tone_prompt(difficulty="beginner")
+        assert "난이도별 조정" in result
+        assert len(result) > len(TONE_EDITOR_PROMPT)
+
+    def test_english_duration_inputs(self):
+        """Test English duration inputs are handled."""
+        result = build_personalized_tone_prompt(duration="10min")
+        assert "분량별 조정" in result
+        assert len(result) > len(TONE_EDITOR_PROMPT)
+
+    def test_custom_base_prompt(self):
+        """Test using a custom base prompt."""
+        custom_prompt = "Custom tone editor prompt"
+        result = build_personalized_tone_prompt(
+            difficulty="초급",
+            duration="5분",
+            base_prompt=custom_prompt
+        )
+        assert custom_prompt in result
+        assert "난이도별 조정" in result
+        assert "분량별 조정" in result
+
+    def test_none_values_treated_as_no_personalization(self):
+        """Test that None values don't add personalization."""
+        result = build_personalized_tone_prompt(difficulty=None, duration=None)
+        assert result == TONE_EDITOR_PROMPT
+
+    def test_empty_string_values_treated_as_no_personalization(self):
+        """Test that empty strings are treated as no personalization."""
+        result = build_personalized_tone_prompt(difficulty="", duration="")
+        # Empty strings are falsy in Python, so they're treated like None
+        assert result == TONE_EDITOR_PROMPT
+
+
+# =============================================================================
+# create_tone_editor_agent Tests
+# =============================================================================
+
+
+class TestCreateToneEditorAgent:
+    """Tests for agent factory function."""
+
+    def test_returns_dict_with_required_keys(self):
+        """Test that agent dict has all required keys."""
+        agent = create_tone_editor_agent()
+        assert "name" in agent
+        assert "description" in agent
+        assert "system_prompt" in agent
+        assert "tools" in agent
+
+    def test_agent_name_is_correct(self):
+        """Test agent name is 'tone-editor'."""
+        agent = create_tone_editor_agent()
+        assert agent["name"] == "tone-editor"
+
+    def test_agent_description_is_korean(self):
+        """Test agent description is in Korean."""
+        agent = create_tone_editor_agent()
+        assert "오토마타" in agent["description"]
+        assert "톤앤매너" in agent["description"]
+
+    def test_agent_has_empty_tools_list(self):
+        """Test agent has no tools."""
+        agent = create_tone_editor_agent()
+        assert agent["tools"] == []
+        assert isinstance(agent["tools"], list)
+
+    def test_default_agent_has_base_prompt(self):
+        """Test agent created with no args has base prompt."""
+        agent = create_tone_editor_agent()
+        assert agent["system_prompt"] == TONE_EDITOR_PROMPT
+
+    def test_agent_with_difficulty(self):
+        """Test agent with difficulty personalization."""
+        agent = create_tone_editor_agent(difficulty="초급")
+        assert len(agent["system_prompt"]) > len(TONE_EDITOR_PROMPT)
+        assert "난이도별 조정" in agent["system_prompt"]
+
+    def test_agent_with_duration(self):
+        """Test agent with duration personalization."""
+        agent = create_tone_editor_agent(duration="10분")
+        assert len(agent["system_prompt"]) > len(TONE_EDITOR_PROMPT)
+        assert "분량별 조정" in agent["system_prompt"]
+
+    def test_agent_with_both_parameters(self):
+        """Test agent with both difficulty and duration."""
+        agent = create_tone_editor_agent(difficulty="고급", duration="15분+")
+        assert "난이도별 조정" in agent["system_prompt"]
+        assert "분량별 조정" in agent["system_prompt"]
+        assert "고급" in agent["system_prompt"]
+        assert "15분+" in agent["system_prompt"]
+
+    def test_multiple_agents_are_independent(self):
+        """Test that creating multiple agents doesn't cause interference."""
+        agent1 = create_tone_editor_agent(difficulty="초급")
+        agent2 = create_tone_editor_agent(difficulty="고급")
+        agent3 = create_tone_editor_agent()
+
+        assert "초급" in agent1["system_prompt"]
+        assert "고급" in agent2["system_prompt"]
+        assert agent3["system_prompt"] == TONE_EDITOR_PROMPT
+
+
+# =============================================================================
+# Default tone_agent Tests
+# =============================================================================
+
+
+class TestDefaultToneAgent:
+    """Tests for the default exported tone_agent."""
+
+    def test_tone_agent_exists(self):
+        """Test that tone_agent is defined."""
+        assert tone_agent is not None
+
+    def test_tone_agent_is_dict(self):
+        """Test that tone_agent is a dictionary."""
+        assert isinstance(tone_agent, dict)
+
+    def test_tone_agent_has_required_keys(self):
+        """Test that tone_agent has all required keys."""
+        assert "name" in tone_agent
+        assert "description" in tone_agent
+        assert "system_prompt" in tone_agent
+        assert "tools" in tone_agent
+
+    def test_tone_agent_uses_base_prompt(self):
+        """Test that default tone_agent uses base prompt."""
+        assert tone_agent["system_prompt"] == TONE_EDITOR_PROMPT
+
+    def test_tone_agent_backward_compatibility(self):
+        """Test that tone_agent maintains backward compatibility."""
+        # The default agent should be identical to calling create_tone_editor_agent()
+        new_agent = create_tone_editor_agent()
+        assert tone_agent["name"] == new_agent["name"]
+        assert tone_agent["description"] == new_agent["description"]
+        assert tone_agent["system_prompt"] == new_agent["system_prompt"]
+        assert tone_agent["tools"] == new_agent["tools"]
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+class TestIntegration:
+    """Integration tests for tone editor personalization."""
+
+    def test_all_difficulty_levels(self):
+        """Test creating agents for all difficulty levels."""
+        difficulties = ["초급", "중급", "고급", "beginner", "intermediate", "advanced"]
+        for difficulty in difficulties:
+            agent = create_tone_editor_agent(difficulty=difficulty)
+            assert "난이도별 조정" in agent["system_prompt"]
+            assert agent["name"] == "tone-editor"
+
+    def test_all_duration_levels(self):
+        """Test creating agents for all duration levels."""
+        durations = ["3분", "5분", "10분", "15분+", "3min", "5min", "10min", "15min+"]
+        for duration in durations:
+            agent = create_tone_editor_agent(duration=duration)
+            assert "분량별 조정" in agent["system_prompt"]
+            assert agent["name"] == "tone-editor"
+
+    def test_all_combinations(self):
+        """Test creating agents for all difficulty-duration combinations."""
+        difficulties = ["초급", "중급", "고급"]
+        durations = ["3분", "5분", "10분", "15분+"]
+
+        for difficulty in difficulties:
+            for duration in durations:
+                agent = create_tone_editor_agent(difficulty=difficulty, duration=duration)
+                assert "난이도별 조정" in agent["system_prompt"]
+                assert "분량별 조정" in agent["system_prompt"]
+                assert difficulty in agent["system_prompt"]
+                assert duration in agent["system_prompt"]
+
+    def test_prompt_length_increases_with_personalization(self):
+        """Test that personalization increases prompt length."""
+        base_agent = create_tone_editor_agent()
+        diff_agent = create_tone_editor_agent(difficulty="초급")
+        dur_agent = create_tone_editor_agent(duration="10분")
+        both_agent = create_tone_editor_agent(difficulty="초급", duration="10분")
+
+        base_len = len(base_agent["system_prompt"])
+        diff_len = len(diff_agent["system_prompt"])
+        dur_len = len(dur_agent["system_prompt"])
+        both_len = len(both_agent["system_prompt"])
+
+        assert diff_len > base_len
+        assert dur_len > base_len
+        assert both_len > diff_len
+        assert both_len > dur_len
+
+
+# =============================================================================
+# Edge Cases and Error Handling
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_invalid_difficulty_gets_normalized(self):
+        """Test invalid difficulty gets normalized to default."""
+        agent = create_tone_editor_agent(difficulty="unknown")
+        # Should normalize to "intermediate" default
+        assert "난이도별 조정" in agent["system_prompt"]
+
+    def test_invalid_duration_gets_normalized(self):
+        """Test invalid duration gets normalized to default."""
+        agent = create_tone_editor_agent(duration="100min")
+        # Should normalize to "5min" default
+        assert "분량별 조정" in agent["system_prompt"]
+
+    def test_empty_string_difficulty(self):
+        """Test empty string difficulty is treated as no personalization."""
+        agent = create_tone_editor_agent(difficulty="")
+        # Empty string is falsy, so treated like None
+        assert agent["system_prompt"] == TONE_EDITOR_PROMPT
+
+    def test_empty_string_duration(self):
+        """Test empty string duration is treated as no personalization."""
+        agent = create_tone_editor_agent(duration="")
+        # Empty string is falsy, so treated like None
+        assert agent["system_prompt"] == TONE_EDITOR_PROMPT
+
+    def test_whitespace_only_inputs(self):
+        """Test whitespace-only inputs are handled."""
+        agent = create_tone_editor_agent(difficulty="   ", duration="   ")
+        assert "난이도별 조정" in agent["system_prompt"]
+        assert "분량별 조정" in agent["system_prompt"]
+
+    def test_unicode_in_inputs(self):
+        """Test unicode characters in inputs don't break functionality."""
+        agent = create_tone_editor_agent(difficulty="초급 ✅", duration="5분 ⏱️")
+        assert "난이도별 조정" in agent["system_prompt"]
+        assert "분량별 조정" in agent["system_prompt"]
+
+    def test_very_long_input_strings(self):
+        """Test very long input strings are handled."""
+        long_difficulty = "초급" + "x" * 1000
+        long_duration = "5분" + "y" * 1000
+        agent = create_tone_editor_agent(difficulty=long_difficulty, duration=long_duration)
+        assert "난이도별 조정" in agent["system_prompt"]
+        assert "분량별 조정" in agent["system_prompt"]
+
+    def test_special_characters_in_inputs(self):
+        """Test special characters in inputs are handled."""
+        agent = create_tone_editor_agent(
+            difficulty="초급 (beginner level)",
+            duration="5분 - 핵심 정리"
+        )
+        assert "난이도별 조정" in agent["system_prompt"]
+        assert "분량별 조정" in agent["system_prompt"]

--- a/src/agents/tone_editor.py
+++ b/src/agents/tone_editor.py
@@ -1,11 +1,122 @@
 """Tone and manner editing subagent for newsletter style consistency."""
 
-from ..config import TONE_EDITOR_PROMPT
+from typing import Optional
+from ..config import (
+    TONE_EDITOR_PROMPT,
+    DIFFICULTY_TONE,
+    DURATION_TONE,
+    normalize_difficulty,
+    normalize_duration,
+)
 
 
-tone_agent = {
-    "name": "tone-editor",
-    "description": "오토마타 뉴스레터 톤앤매너 교정. 친근하면서도 전문적인 해요체로 아티클을 교정합니다.",
-    "system_prompt": TONE_EDITOR_PROMPT,
-    "tools": [],  # No tools needed - uses text editing only
-}
+def build_personalized_tone_prompt(
+    difficulty: Optional[str] = None,
+    duration: Optional[str] = None,
+    base_prompt: str = TONE_EDITOR_PROMPT,
+) -> str:
+    """
+    Build personalized tone editor prompt based on user preferences.
+
+    Args:
+        difficulty: User's difficulty level (초급/중급/고급 or beginner/intermediate/advanced)
+        duration: User's preferred duration (3분/5분/10분/15분+ or 3min/5min/10min/15min+)
+        base_prompt: Base tone editor prompt
+
+    Returns:
+        Customized system prompt with personalization guidelines
+    """
+    additions = []
+
+    if difficulty:
+        normalized = normalize_difficulty(difficulty)
+        tone_config = DIFFICULTY_TONE.get(normalized, DIFFICULTY_TONE["intermediate"])
+
+        additions.append(f"\n## 난이도별 조정 (사용자 선택: {difficulty})")
+        additions.append(f"- 용어 설명 수준: {tone_config['term_explanation']}")
+        additions.append(f"- 비유 사용: {tone_config['analogy_usage']}")
+        additions.append(f"- 기술적 깊이: {tone_config['technical_depth']}")
+
+        # Add specific examples based on level
+        if normalized == "beginner":
+            additions.append(
+                "\n모든 기술 용어를 상세히 설명하고, 일상적인 비유를 많이 사용하세요."
+            )
+            additions.append(
+                "예: 'RAG(Retrieval-Augmented Generation, 검색 증강 생성)는 AI가 외부 지식을 검색해서 답변하는 방식이에요. 쉽게 말해, AI가 인터넷 검색하면서 답하는 것과 비슷해요.'"
+            )
+        elif normalized == "intermediate":
+            additions.append(
+                "\n핵심 용어만 간단히 설명하고, 실무 적용에 초점을 맞추세요."
+            )
+            additions.append(
+                "예: 'RAG(검색 증강 생성)는 외부 지식베이스를 활용하는 기법이에요.'"
+            )
+        elif normalized == "advanced":
+            additions.append(
+                "\n기술 용어 설명을 최소화하고, 전문적인 내용에 집중하세요."
+            )
+            additions.append(
+                "예: 'RAG 아키텍처에서 retriever와 generator의 결합 방식...'"
+            )
+
+    if duration:
+        normalized = normalize_duration(duration)
+        duration_config = DURATION_TONE.get(normalized, DURATION_TONE["5min"])
+
+        additions.append(f"\n## 분량별 조정 (사용자 선택: {duration})")
+        additions.append(f"- 섹션 상세도: {duration_config['section_detail']}")
+        additions.append(f"- 예시 개수: {duration_config['examples']}")
+        additions.append(
+            f"- 코드 스니펫 포함: {'예' if duration_config['code_snippets'] else '아니오'}"
+        )
+
+        # Add specific guidance based on duration
+        if normalized == "3min":
+            additions.append(
+                "\n핵심만 간결하게 전달하세요. 예시는 생략하고 주요 포인트만 나열하세요."
+            )
+        elif normalized == "5min":
+            additions.append(
+                "\n균형잡힌 분량으로 핵심을 설명하세요. 중요한 예시 1개 정도를 포함하세요."
+            )
+        elif normalized == "10min":
+            additions.append(
+                "\n상세한 설명을 제공하세요. 예시 2개와 코드 스니펫을 포함할 수 있습니다."
+            )
+        elif normalized == "15min+":
+            additions.append(
+                "\n깊이 있는 분석을 제공하세요. 다양한 예시와 코드 스니펫을 포함하여 종합적으로 설명하세요."
+            )
+
+    if additions:
+        return base_prompt + "\n".join(additions)
+
+    return base_prompt
+
+
+def create_tone_editor_agent(
+    difficulty: Optional[str] = None, duration: Optional[str] = None
+):
+    """
+    Create tone editor agent with optional personalization.
+
+    Args:
+        difficulty: User's difficulty preference (초급/중급/고급 or beginner/intermediate/advanced)
+        duration: User's duration preference (3분/5분/10분/15분+ or 3min/5min/10min/15min+)
+
+    Returns:
+        Tone editor agent configuration dict
+    """
+    system_prompt = build_personalized_tone_prompt(difficulty, duration)
+
+    return {
+        "name": "tone-editor",
+        "description": "오토마타 뉴스레터 톤앤매너 교정. 친근하면서도 전문적인 해요체로 아티클을 교정합니다.",
+        "system_prompt": system_prompt,
+        "tools": [],  # No tools needed - uses text editing only
+    }
+
+
+# Default agent for backward compatibility
+tone_agent = create_tone_editor_agent()

--- a/src/api/newsletter_generator.py
+++ b/src/api/newsletter_generator.py
@@ -10,7 +10,7 @@ from deepagents import create_deep_agent
 from langsmith import Client as LangSmithClient
 
 from ..config import ANTHROPIC_API_KEY, TAVILY_API_KEY
-from ..agents import create_research_subagent, topic_selection_agent, tone_agent
+from ..agents import create_research_subagent, topic_selection_agent, create_tone_editor_agent
 from .models import (
     NewsletterContext,
     ProgressUpdate,
@@ -52,6 +52,7 @@ class NewsletterGenerator:
         preferred_sources = []
         goal = None
         difficulty = None
+        duration = None
 
         for answer in context.user_answers:
             if answer.skipped:
@@ -86,6 +87,13 @@ class NewsletterGenerator:
                 elif answer.answer_text:
                     difficulty = answer.answer_text.lower()
 
+            elif answer.question_type == "time":
+                # Extract duration preference
+                if answer.answer_value and "value" in answer.answer_value:
+                    duration = answer.answer_value["value"]
+                elif answer.answer_text:
+                    duration = answer.answer_text.lower()
+
         # Add to research context if present
         if subtopics:
             research_context["subtopics"] = subtopics
@@ -95,6 +103,8 @@ class NewsletterGenerator:
             research_context["goal"] = goal
         if difficulty or context.user_preferences.get("difficulty"):
             research_context["difficulty"] = difficulty or context.user_preferences.get("difficulty")
+        if duration or context.user_preferences.get("duration"):
+            research_context["duration"] = duration or context.user_preferences.get("duration")
 
         return research_context
 
@@ -231,11 +241,17 @@ class NewsletterGenerator:
             # Create personalized research agent
             research_agent = create_research_subagent(research_context)
 
+            # Create personalized tone editor agent
+            tone_editor = create_tone_editor_agent(
+                difficulty=research_context.get("difficulty"),
+                duration=research_context.get("duration"),
+            )
+
             # Create agent
             agent = create_deep_agent(
                 system_prompt="You are an expert research newsletter writer. Follow the user's instructions carefully and produce high-quality, well-researched content.",
                 tools=[],  # No tools needed, subagents have them
-                subagents=[research_agent, topic_selection_agent, tone_agent],
+                subagents=[research_agent, topic_selection_agent, tone_editor],
             )
 
             # Configure LangSmith metadata
@@ -368,11 +384,17 @@ class NewsletterGenerator:
             # Create personalized research agent
             research_agent = create_research_subagent(research_context)
 
+            # Create personalized tone editor agent
+            tone_editor = create_tone_editor_agent(
+                difficulty=research_context.get("difficulty"),
+                duration=research_context.get("duration"),
+            )
+
             # Create agent
             agent = create_deep_agent(
                 system_prompt="You are an expert research newsletter writer. Follow the user's instructions carefully and produce high-quality, well-researched content.",
                 tools=[],
-                subagents=[research_agent, topic_selection_agent, tone_agent],
+                subagents=[research_agent, topic_selection_agent, tone_editor],
             )
 
             config: Dict[str, Any] = {

--- a/src/api/test_newsletter_generator.py
+++ b/src/api/test_newsletter_generator.py
@@ -1,0 +1,363 @@
+"""Tests for newsletter generator duration extraction."""
+
+import pytest
+from .newsletter_generator import NewsletterGenerator
+from .models import NewsletterContext, UserAnswer
+
+
+class TestExtractResearchContext:
+    """Tests for _extract_research_context method."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.generator = NewsletterGenerator()
+
+    def test_extract_duration_from_answer_value(self):
+        """Test extracting duration from answer_value."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="Test Topic",
+            user_answers=[
+                UserAnswer(
+                    question_id="q1",
+                    question_text="뉴스레터 분량은 어느 정도가 좋을까요?",
+                    question_type="time",
+                    answer_value={"value": "5분 (핵심 정리)"},
+                    skipped=False,
+                )
+            ],
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        assert "duration" in research_context
+        assert research_context["duration"] == "5분 (핵심 정리)"
+
+    def test_extract_duration_from_answer_text(self):
+        """Test extracting duration from answer_text."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="Test Topic",
+            user_answers=[
+                UserAnswer(
+                    question_id="q1",
+                    question_text="뉴스레터 분량은 어느 정도가 좋을까요?",
+                    question_type="time",
+                    answer_text="10분 (상세 설명)",
+                    skipped=False,
+                )
+            ],
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        assert "duration" in research_context
+        assert research_context["duration"] == "10분 (상세 설명)"
+
+    def test_skipped_duration_answer_not_extracted(self):
+        """Test that skipped time answers are not extracted."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="Test Topic",
+            user_answers=[
+                UserAnswer(
+                    question_id="q1",
+                    question_text="뉴스레터 분량은 어느 정도가 좋을까요?",
+                    question_type="time",
+                    answer_value={"value": "5분"},
+                    skipped=True,
+                )
+            ],
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        assert "duration" not in research_context
+
+    def test_duration_from_user_preferences(self):
+        """Test duration extracted from user_preferences."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="Test Topic",
+            user_preferences={"duration": "15분+"},
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        assert "duration" in research_context
+        assert research_context["duration"] == "15분+"
+
+    def test_duration_answer_overrides_preferences(self):
+        """Test that answer value takes precedence over preferences."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="Test Topic",
+            user_answers=[
+                UserAnswer(
+                    question_id="q1",
+                    question_text="뉴스레터 분량은 어느 정도가 좋을까요?",
+                    question_type="time",
+                    answer_value={"value": "10분"},
+                    skipped=False,
+                )
+            ],
+            user_preferences={"duration": "5분"},
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        assert research_context["duration"] == "10분"
+
+    def test_extract_difficulty_still_works(self):
+        """Test that existing difficulty extraction still works."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="Test Topic",
+            user_answers=[
+                UserAnswer(
+                    question_id="q1",
+                    question_text="어느 정도 수준의 설명을 원하시나요?",
+                    question_type="difficulty",
+                    answer_value={"value": "중급 (실무 활용)"},
+                    skipped=False,
+                )
+            ],
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        assert "difficulty" in research_context
+        assert research_context["difficulty"] == "중급 (실무 활용)"
+
+    def test_extract_both_difficulty_and_duration(self):
+        """Test extracting both difficulty and duration together."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="Test Topic",
+            user_answers=[
+                UserAnswer(
+                    question_id="q1",
+                    question_text="어느 정도 수준의 설명을 원하시나요?",
+                    question_type="difficulty",
+                    answer_value={"value": "초급 (기본 개념부터)"},
+                    skipped=False,
+                ),
+                UserAnswer(
+                    question_id="q2",
+                    question_text="뉴스레터 분량은 어느 정도가 좋을까요?",
+                    question_type="time",
+                    answer_value={"value": "3분 (빠른 요약)"},
+                    skipped=False,
+                ),
+            ],
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        assert "difficulty" in research_context
+        assert "duration" in research_context
+        assert research_context["difficulty"] == "초급 (기본 개념부터)"
+        assert research_context["duration"] == "3분 (빠른 요약)"
+
+    def test_extract_all_question_types(self):
+        """Test extracting all supported question types."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="AI 에이전트",
+            user_answers=[
+                UserAnswer(
+                    question_id="q1",
+                    question_text="목적",
+                    question_type="goal",
+                    answer_value={"value": "업무 적용"},
+                    skipped=False,
+                ),
+                UserAnswer(
+                    question_id="q2",
+                    question_text="난이도",
+                    question_type="difficulty",
+                    answer_value={"value": "중급"},
+                    skipped=False,
+                ),
+                UserAnswer(
+                    question_id="q3",
+                    question_text="시간",
+                    question_type="time",
+                    answer_value={"value": "10분"},
+                    skipped=False,
+                ),
+                UserAnswer(
+                    question_id="q4",
+                    question_text="소스",
+                    question_type="source",
+                    answer_value={"values": ["공식 문서", "기술 블로그"]},
+                    skipped=False,
+                ),
+                UserAnswer(
+                    question_id="q5",
+                    question_text="관심 범위",
+                    question_type="scope",
+                    answer_value={"values": ["기술 구현", "오픈소스"]},
+                    skipped=False,
+                ),
+                UserAnswer(
+                    question_id="q6",
+                    question_text="하위 주제",
+                    question_type="subtopic",
+                    answer_text="LangChain, LangGraph",
+                    skipped=False,
+                ),
+            ],
+        )
+
+        research_context = self.generator._extract_research_context(context)
+
+        # Check all fields are extracted
+        assert research_context["topic"] == "AI 에이전트"
+        assert research_context["goal"] == "업무 적용"
+        assert research_context["difficulty"] == "중급"
+        assert research_context["duration"] == "10분"
+        assert "공식 문서" in research_context["preferred_sources"]
+        assert "기술 블로그" in research_context["preferred_sources"]
+        assert "LangChain, LangGraph" in research_context["subtopics"]
+
+    def test_no_duration_answer_no_duration_in_context(self):
+        """Test that absence of duration answer results in no duration key."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="Test Topic",
+            user_answers=[
+                UserAnswer(
+                    question_id="q1",
+                    question_text="난이도",
+                    question_type="difficulty",
+                    answer_value={"value": "초급"},
+                    skipped=False,
+                )
+            ],
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        assert "difficulty" in research_context
+        assert "duration" not in research_context
+
+    def test_multiple_time_answers_uses_last(self):
+        """Test that multiple time answers uses the last one."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="Test Topic",
+            user_answers=[
+                UserAnswer(
+                    question_id="q1",
+                    question_text="시간1",
+                    question_type="time",
+                    answer_value={"value": "3분"},
+                    skipped=False,
+                ),
+                UserAnswer(
+                    question_id="q2",
+                    question_text="시간2",
+                    question_type="time",
+                    answer_value={"value": "10분"},
+                    skipped=False,
+                ),
+            ],
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        # Should use the last value encountered
+        assert research_context["duration"] == "10분"
+
+    def test_duration_text_is_lowercased(self):
+        """Test that duration text answer is lowercased."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="Test Topic",
+            user_answers=[
+                UserAnswer(
+                    question_id="q1",
+                    question_text="시간",
+                    question_type="time",
+                    answer_text="10MIN",
+                    skipped=False,
+                )
+            ],
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        assert research_context["duration"] == "10min"
+
+    def test_empty_user_answers_list(self):
+        """Test extraction with empty user answers list."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="Test Topic",
+            user_answers=[],
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        assert research_context["topic"] == "Test Topic"
+        assert "duration" not in research_context
+        assert "difficulty" not in research_context
+
+    def test_topic_description_included(self):
+        """Test that topic description is included in context."""
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="AI 에이전트",
+            topic_description="최신 AI 에이전트 기술 동향",
+            user_answers=[],
+        )
+
+        research_context = self.generator._extract_research_context(context)
+        assert research_context["topic"] == "AI 에이전트"
+        assert research_context["topic_description"] == "최신 AI 에이전트 기술 동향"
+
+
+class TestDurationIntegration:
+    """Integration tests for duration in the full pipeline."""
+
+    def test_duration_extraction_matches_default_questions(self):
+        """Test that duration extraction works with default question format."""
+        # This mirrors the actual question format from default-questions.ts
+        context = NewsletterContext(
+            topic_id="topic-123",
+            topic_text="AI 에이전트 최신 동향",
+            user_answers=[
+                UserAnswer(
+                    question_id="q1",
+                    question_text="뉴스레터 분량은 어느 정도가 좋을까요?",
+                    question_type="time",
+                    answer_value={"value": "5분 (핵심 정리)"},
+                    skipped=False,
+                )
+            ],
+        )
+
+        generator = NewsletterGenerator()
+        research_context = generator._extract_research_context(context)
+
+        assert "duration" in research_context
+        assert "5분" in research_context["duration"]
+
+    def test_all_duration_options_from_default_questions(self):
+        """Test all duration options from default questions."""
+        duration_options = [
+            "3분 (빠른 요약)",
+            "5분 (핵심 정리)",
+            "10분 (상세 설명)",
+            "15분+ (깊이 있는 분석)",
+        ]
+
+        generator = NewsletterGenerator()
+
+        for option in duration_options:
+            context = NewsletterContext(
+                topic_id="topic-123",
+                topic_text="Test",
+                user_answers=[
+                    UserAnswer(
+                        question_id="q1",
+                        question_text="뉴스레터 분량은 어느 정도가 좋을까요?",
+                        question_type="time",
+                        answer_value={"value": option},
+                        skipped=False,
+                    )
+                ],
+            )
+
+            research_context = generator._extract_research_context(context)
+            assert research_context["duration"] == option

--- a/src/config.py
+++ b/src/config.py
@@ -218,6 +218,98 @@ TONE_EDITOR_PROMPT = """당신은 '오토마타' 뉴스레터의 에디터입니
 주어진 아티클을 위 가이드에 맞게 교정하되, 핵심 정보는 유지하세요.
 """
 
+# Difficulty-based tone configurations
+DIFFICULTY_TONE = {
+    "beginner": {
+        "term_explanation": "detailed",
+        "analogy_usage": "high",
+        "technical_depth": "low",
+    },
+    "intermediate": {
+        "term_explanation": "brief",
+        "analogy_usage": "medium",
+        "technical_depth": "medium",
+    },
+    "advanced": {
+        "term_explanation": "minimal",
+        "analogy_usage": "low",
+        "technical_depth": "high",
+    },
+}
+
+# Duration-based tone configurations
+DURATION_TONE = {
+    "3min": {
+        "section_detail": "concise",
+        "examples": 0,
+        "code_snippets": False,
+    },
+    "5min": {
+        "section_detail": "balanced",
+        "examples": 1,
+        "code_snippets": False,
+    },
+    "10min": {
+        "section_detail": "detailed",
+        "examples": 2,
+        "code_snippets": True,
+    },
+    "15min+": {
+        "section_detail": "comprehensive",
+        "examples": 3,
+        "code_snippets": True,
+    },
+}
+
+
+def normalize_difficulty(difficulty: str) -> str:
+    """
+    Normalize difficulty input to standard keys.
+
+    Args:
+        difficulty: Difficulty level in Korean or English
+
+    Returns:
+        Normalized difficulty: "beginner", "intermediate", or "advanced"
+    """
+    difficulty_lower = difficulty.lower()
+
+    if "초급" in difficulty_lower or "기본" in difficulty_lower or "beginner" in difficulty_lower:
+        return "beginner"
+    elif "중급" in difficulty_lower or "실무" in difficulty_lower or "intermediate" in difficulty_lower:
+        return "intermediate"
+    elif "고급" in difficulty_lower or "전문가" in difficulty_lower or "advanced" in difficulty_lower:
+        return "advanced"
+
+    # Default to intermediate
+    return "intermediate"
+
+
+def normalize_duration(duration: str) -> str:
+    """
+    Normalize duration input to standard keys.
+
+    Args:
+        duration: Reading duration preference in Korean or English
+
+    Returns:
+        Normalized duration: "3min", "5min", "10min", or "15min+"
+    """
+    duration_lower = duration.lower()
+
+    if "3분" in duration_lower or "3min" in duration_lower or "빠른" in duration_lower or "요약" in duration_lower:
+        return "3min"
+    elif "5분" in duration_lower or "5min" in duration_lower or "핵심" in duration_lower:
+        return "5min"
+    elif "10분" in duration_lower or "10min" in duration_lower or "상세" in duration_lower:
+        return "10min"
+    elif "15분" in duration_lower or "15min" in duration_lower or "깊이" in duration_lower or "분석" in duration_lower:
+        return "15min+"
+
+    # Default to 5min
+    return "5min"
+
+
 # Newsletter template
 NEWSLETTER_HEADER_TEMPLATE = """# Automata V.{version} | {main_title}
 

--- a/src/config.py
+++ b/src/config.py
@@ -297,14 +297,15 @@ def normalize_duration(duration: str) -> str:
     """
     duration_lower = duration.lower()
 
-    if "3분" in duration_lower or "3min" in duration_lower or "빠른" in duration_lower or "요약" in duration_lower:
-        return "3min"
-    elif "5분" in duration_lower or "5min" in duration_lower or "핵심" in duration_lower:
-        return "5min"
+    # Check longer patterns first to avoid substring matching issues
+    if "15분" in duration_lower or "15min" in duration_lower or "깊이" in duration_lower or "분석" in duration_lower:
+        return "15min+"
     elif "10분" in duration_lower or "10min" in duration_lower or "상세" in duration_lower:
         return "10min"
-    elif "15분" in duration_lower or "15min" in duration_lower or "깊이" in duration_lower or "분석" in duration_lower:
-        return "15min+"
+    elif "5분" in duration_lower or "5min" in duration_lower or "핵심" in duration_lower:
+        return "5min"
+    elif "3분" in duration_lower or "3min" in duration_lower or "빠른" in duration_lower or "요약" in duration_lower:
+        return "3min"
 
     # Default to 5min
     return "5min"

--- a/src/test_config.py
+++ b/src/test_config.py
@@ -1,0 +1,382 @@
+"""Comprehensive tests for config normalization functions."""
+
+import pytest
+from .config import (
+    normalize_difficulty,
+    normalize_duration,
+    DIFFICULTY_TONE,
+    DURATION_TONE,
+)
+
+
+# =============================================================================
+# normalize_difficulty Tests
+# =============================================================================
+
+
+class TestNormalizeDifficulty:
+    """Tests for difficulty normalization function."""
+
+    def test_korean_beginner_variations(self):
+        """Test various Korean beginner inputs."""
+        beginner_inputs = [
+            "초급",
+            "초급 (기본 개념부터)",
+            "기본",
+            "기본 개념",
+            "초급자",
+        ]
+        for input_text in beginner_inputs:
+            assert normalize_difficulty(input_text) == "beginner", f"Failed for: {input_text}"
+
+    def test_english_beginner(self):
+        """Test English beginner input."""
+        assert normalize_difficulty("beginner") == "beginner"
+        assert normalize_difficulty("Beginner") == "beginner"
+        assert normalize_difficulty("BEGINNER") == "beginner"
+
+    def test_korean_intermediate_variations(self):
+        """Test various Korean intermediate inputs."""
+        intermediate_inputs = [
+            "중급",
+            "중급 (실무 활용)",
+            "실무",
+            "실무 활용",
+            "중급자",
+        ]
+        for input_text in intermediate_inputs:
+            assert normalize_difficulty(input_text) == "intermediate", f"Failed for: {input_text}"
+
+    def test_english_intermediate(self):
+        """Test English intermediate input."""
+        assert normalize_difficulty("intermediate") == "intermediate"
+        assert normalize_difficulty("Intermediate") == "intermediate"
+        assert normalize_difficulty("INTERMEDIATE") == "intermediate"
+
+    def test_korean_advanced_variations(self):
+        """Test various Korean advanced inputs."""
+        advanced_inputs = [
+            "고급",
+            "고급 (전문가 수준)",
+            "전문가",
+            "전문가 수준",
+            "고급자",
+        ]
+        for input_text in advanced_inputs:
+            assert normalize_difficulty(input_text) == "advanced", f"Failed for: {input_text}"
+
+    def test_english_advanced(self):
+        """Test English advanced input."""
+        assert normalize_difficulty("advanced") == "advanced"
+        assert normalize_difficulty("Advanced") == "advanced"
+        assert normalize_difficulty("ADVANCED") == "advanced"
+
+    def test_invalid_input_defaults_to_intermediate(self):
+        """Test that invalid inputs default to intermediate."""
+        invalid_inputs = [
+            "unknown",
+            "random",
+            "master",
+            "expert",
+            "",
+            "   ",
+        ]
+        for input_text in invalid_inputs:
+            assert normalize_difficulty(input_text) == "intermediate", f"Failed for: {input_text}"
+
+    def test_mixed_case_inputs(self):
+        """Test mixed case inputs."""
+        assert normalize_difficulty("초급") == "beginner"
+        assert normalize_difficulty("BEGINNER") == "beginner"
+        assert normalize_difficulty("BeGiNnEr") == "beginner"
+
+    def test_whitespace_handling(self):
+        """Test inputs with extra whitespace."""
+        assert normalize_difficulty("  초급  ") == "beginner"
+        assert normalize_difficulty("중급 ") == "intermediate"
+        assert normalize_difficulty(" 고급") == "advanced"
+
+
+# =============================================================================
+# normalize_duration Tests
+# =============================================================================
+
+
+class TestNormalizeDuration:
+    """Tests for duration normalization function."""
+
+    def test_korean_3min_variations(self):
+        """Test various Korean 3min inputs."""
+        three_min_inputs = [
+            "3분",
+            "3분 (빠른 요약)",
+            "빠른",
+            "빠른 요약",
+            "요약",
+        ]
+        for input_text in three_min_inputs:
+            assert normalize_duration(input_text) == "3min", f"Failed for: {input_text}"
+
+    def test_english_3min(self):
+        """Test English 3min input."""
+        assert normalize_duration("3min") == "3min"
+        assert normalize_duration("3MIN") == "3min"
+        assert normalize_duration("3Min") == "3min"
+
+    def test_korean_5min_variations(self):
+        """Test various Korean 5min inputs."""
+        five_min_inputs = [
+            "5분",
+            "5분 (핵심 정리)",
+            "핵심",
+            "핵심 정리",
+        ]
+        for input_text in five_min_inputs:
+            assert normalize_duration(input_text) == "5min", f"Failed for: {input_text}"
+
+    def test_english_5min(self):
+        """Test English 5min input."""
+        assert normalize_duration("5min") == "5min"
+        assert normalize_duration("5MIN") == "5min"
+        assert normalize_duration("5Min") == "5min"
+
+    def test_korean_10min_variations(self):
+        """Test various Korean 10min inputs."""
+        ten_min_inputs = [
+            "10분",
+            "10분 (상세 설명)",
+            "상세",
+            "상세 설명",
+        ]
+        for input_text in ten_min_inputs:
+            assert normalize_duration(input_text) == "10min", f"Failed for: {input_text}"
+
+    def test_english_10min(self):
+        """Test English 10min input."""
+        assert normalize_duration("10min") == "10min"
+        assert normalize_duration("10MIN") == "10min"
+        assert normalize_duration("10Min") == "10min"
+
+    def test_korean_15min_variations(self):
+        """Test various Korean 15min+ inputs."""
+        fifteen_min_inputs = [
+            "15분",
+            "15분+",
+            "15분+ (깊이 있는 분석)",
+            "깊이",
+            "깊이 있는",
+            "분석",
+        ]
+        for input_text in fifteen_min_inputs:
+            assert normalize_duration(input_text) == "15min+", f"Failed for: {input_text}"
+
+    def test_english_15min(self):
+        """Test English 15min+ input."""
+        assert normalize_duration("15min") == "15min+"
+        assert normalize_duration("15min+") == "15min+"
+        assert normalize_duration("15MIN+") == "15min+"
+
+    def test_invalid_input_defaults_to_5min(self):
+        """Test that invalid inputs default to 5min."""
+        invalid_inputs = [
+            "unknown",
+            "random",
+            "20min",
+            "1hour",
+            "",
+            "   ",
+        ]
+        for input_text in invalid_inputs:
+            assert normalize_duration(input_text) == "5min", f"Failed for: {input_text}"
+
+    def test_mixed_case_inputs(self):
+        """Test mixed case inputs."""
+        assert normalize_duration("3분") == "3min"
+        assert normalize_duration("3MIN") == "3min"
+        assert normalize_duration("3MiN") == "3min"
+
+    def test_whitespace_handling(self):
+        """Test inputs with extra whitespace."""
+        assert normalize_duration("  3분  ") == "3min"
+        assert normalize_duration("5분 ") == "5min"
+        assert normalize_duration(" 10분") == "10min"
+
+
+# =============================================================================
+# Configuration Dictionaries Tests
+# =============================================================================
+
+
+class TestDifficultyToneConfig:
+    """Tests for DIFFICULTY_TONE configuration."""
+
+    def test_has_all_levels(self):
+        """Test that all difficulty levels are defined."""
+        assert "beginner" in DIFFICULTY_TONE
+        assert "intermediate" in DIFFICULTY_TONE
+        assert "advanced" in DIFFICULTY_TONE
+
+    def test_beginner_config_structure(self):
+        """Test beginner configuration has required keys."""
+        config = DIFFICULTY_TONE["beginner"]
+        assert "term_explanation" in config
+        assert "analogy_usage" in config
+        assert "technical_depth" in config
+
+    def test_intermediate_config_structure(self):
+        """Test intermediate configuration has required keys."""
+        config = DIFFICULTY_TONE["intermediate"]
+        assert "term_explanation" in config
+        assert "analogy_usage" in config
+        assert "technical_depth" in config
+
+    def test_advanced_config_structure(self):
+        """Test advanced configuration has required keys."""
+        config = DIFFICULTY_TONE["advanced"]
+        assert "term_explanation" in config
+        assert "analogy_usage" in config
+        assert "technical_depth" in config
+
+    def test_beginner_values(self):
+        """Test beginner has appropriate values."""
+        config = DIFFICULTY_TONE["beginner"]
+        assert config["term_explanation"] == "detailed"
+        assert config["analogy_usage"] == "high"
+        assert config["technical_depth"] == "low"
+
+    def test_intermediate_values(self):
+        """Test intermediate has appropriate values."""
+        config = DIFFICULTY_TONE["intermediate"]
+        assert config["term_explanation"] == "brief"
+        assert config["analogy_usage"] == "medium"
+        assert config["technical_depth"] == "medium"
+
+    def test_advanced_values(self):
+        """Test advanced has appropriate values."""
+        config = DIFFICULTY_TONE["advanced"]
+        assert config["term_explanation"] == "minimal"
+        assert config["analogy_usage"] == "low"
+        assert config["technical_depth"] == "high"
+
+
+class TestDurationToneConfig:
+    """Tests for DURATION_TONE configuration."""
+
+    def test_has_all_durations(self):
+        """Test that all duration levels are defined."""
+        assert "3min" in DURATION_TONE
+        assert "5min" in DURATION_TONE
+        assert "10min" in DURATION_TONE
+        assert "15min+" in DURATION_TONE
+
+    def test_3min_config_structure(self):
+        """Test 3min configuration has required keys."""
+        config = DURATION_TONE["3min"]
+        assert "section_detail" in config
+        assert "examples" in config
+        assert "code_snippets" in config
+
+    def test_5min_config_structure(self):
+        """Test 5min configuration has required keys."""
+        config = DURATION_TONE["5min"]
+        assert "section_detail" in config
+        assert "examples" in config
+        assert "code_snippets" in config
+
+    def test_10min_config_structure(self):
+        """Test 10min configuration has required keys."""
+        config = DURATION_TONE["10min"]
+        assert "section_detail" in config
+        assert "examples" in config
+        assert "code_snippets" in config
+
+    def test_15min_config_structure(self):
+        """Test 15min+ configuration has required keys."""
+        config = DURATION_TONE["15min+"]
+        assert "section_detail" in config
+        assert "examples" in config
+        assert "code_snippets" in config
+
+    def test_3min_values(self):
+        """Test 3min has appropriate values."""
+        config = DURATION_TONE["3min"]
+        assert config["section_detail"] == "concise"
+        assert config["examples"] == 0
+        assert config["code_snippets"] is False
+
+    def test_5min_values(self):
+        """Test 5min has appropriate values."""
+        config = DURATION_TONE["5min"]
+        assert config["section_detail"] == "balanced"
+        assert config["examples"] == 1
+        assert config["code_snippets"] is False
+
+    def test_10min_values(self):
+        """Test 10min has appropriate values."""
+        config = DURATION_TONE["10min"]
+        assert config["section_detail"] == "detailed"
+        assert config["examples"] == 2
+        assert config["code_snippets"] is True
+
+    def test_15min_values(self):
+        """Test 15min+ has appropriate values."""
+        config = DURATION_TONE["15min+"]
+        assert config["section_detail"] == "comprehensive"
+        assert config["examples"] == 3
+        assert config["code_snippets"] is True
+
+    def test_example_counts_are_progressive(self):
+        """Test that example counts increase with duration."""
+        assert DURATION_TONE["3min"]["examples"] < DURATION_TONE["5min"]["examples"]
+        assert DURATION_TONE["5min"]["examples"] < DURATION_TONE["10min"]["examples"]
+        assert DURATION_TONE["10min"]["examples"] < DURATION_TONE["15min+"]["examples"]
+
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases in normalization functions."""
+
+    def test_empty_string_difficulty(self):
+        """Test empty string defaults to intermediate."""
+        assert normalize_difficulty("") == "intermediate"
+
+    def test_empty_string_duration(self):
+        """Test empty string defaults to 5min."""
+        assert normalize_duration("") == "5min"
+
+    def test_only_whitespace_difficulty(self):
+        """Test whitespace-only string defaults to intermediate."""
+        assert normalize_difficulty("   ") == "intermediate"
+        assert normalize_difficulty("\t\n") == "intermediate"
+
+    def test_only_whitespace_duration(self):
+        """Test whitespace-only string defaults to 5min."""
+        assert normalize_duration("   ") == "5min"
+        assert normalize_duration("\t\n") == "5min"
+
+    def test_partial_match_difficulty(self):
+        """Test partial matches work correctly."""
+        assert normalize_difficulty("this is beginner level") == "beginner"
+        assert normalize_difficulty("실무 중심 중급") == "intermediate"
+        assert normalize_difficulty("전문가용 고급") == "advanced"
+
+    def test_partial_match_duration(self):
+        """Test partial matches work correctly."""
+        assert normalize_duration("선택: 3분 빠른 요약") == "3min"
+        assert normalize_duration("원하는 시간: 5분") == "5min"
+        assert normalize_duration("깊이 있게 15분 이상") == "15min+"
+
+    def test_unicode_characters(self):
+        """Test handling of special unicode characters."""
+        assert normalize_difficulty("초급 ✅") == "beginner"
+        assert normalize_duration("5분 ⏱️") == "5min"
+
+    def test_numbers_only(self):
+        """Test numbers without 'min' suffix."""
+        # Should not match since we look for "3분" or "3min"
+        assert normalize_duration("3") == "5min"  # default
+        assert normalize_duration("10") == "5min"  # default

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -103,7 +103,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2220,7 +2219,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.91.0.tgz",
       "integrity": "sha512-Rjb0QqkKrmXMVwUOdEqysPBZ0ZDZakeptTkUa6k2d8r3strBdbWVDqjOdkCjAmvvZMtXecBeyTyMEXD1Zzjfvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.91.0",
         "@supabase/functions-js": "2.91.0",
@@ -2599,6 +2597,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2695,7 +2694,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2816,7 +2816,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2827,7 +2826,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2945,7 +2943,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -3579,7 +3576,6 @@
       "integrity": "sha512-hRDjg6dlDz7JlZAvjbiCdAJ3SDG+NH8tjZe21vjxfvT2ssYAn72SRXMge3dKKABm3bIJ3C+3wdunIdur8PHEAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.17",
         "fflate": "^0.8.2",
@@ -3623,7 +3619,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3664,6 +3659,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4029,7 +4025,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4341,8 +4336,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4528,7 +4522,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.3.1",
@@ -4851,7 +4846,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5053,7 +5047,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5732,7 +5725,6 @@
       "integrity": "sha512-rfbiwB6OKxZFIFQ7SRnCPB2WL9WhyXsFoTfecYgeCeFSOBxvkWLaXsdv5ehzJrfqwXQmDephAKWLRQoFoJwrew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -7088,6 +7080,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8578,7 +8571,6 @@
       "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8674,6 +8666,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8689,6 +8682,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8701,7 +8695,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -8780,7 +8775,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8790,7 +8784,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8803,7 +8796,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9927,7 +9919,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10130,7 +10121,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10408,7 +10398,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10502,7 +10491,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10516,7 +10504,6 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",
@@ -10790,7 +10777,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

Implements tone editor personalization based on user preferences for difficulty level and reading duration.

### Changes

1. **Configuration (src/config.py)**
   - Added `DIFFICULTY_TONE` mapping (beginner/intermediate/advanced)
   - Added `DURATION_TONE` mapping (3min/5min/10min/15min+)
   - Added `normalize_difficulty()` function for input normalization
   - Added `normalize_duration()` function for input normalization

2. **Tone Editor Agent (src/agents/tone_editor.py)**
   - Added `build_personalized_tone_prompt()` function
   - Added `create_tone_editor_agent()` factory function
   - Maintains backward compatibility with default `tone_agent`
   - Difficulty-based adjustments:
     - Beginner: Detailed term explanations, high analogy usage, low technical depth
     - Intermediate: Brief explanations, medium analogies, medium depth
     - Advanced: Minimal explanations, low analogies, high technical depth
   - Duration-based adjustments:
     - 3min: Concise, 0 examples, no code snippets
     - 5min: Balanced, 1 example, no code snippets
     - 10min: Detailed, 2 examples, code snippets included
     - 15min+: Comprehensive, 3 examples, code snippets included

3. **Newsletter Generator (src/api/newsletter_generator.py)**
   - Added duration extraction from user answers ("time" question type)
   - Wired personalized tone editor in both sync and stream methods
   - Passes difficulty and duration to tone editor factory

4. **Comprehensive Tests (102 total)**
   - `src/test_config.py`: 45 tests for normalization functions
   - `src/agents/test_tone_editor.py`: 42 tests for tone editor personalization
   - `src/api/test_newsletter_generator.py`: 15 tests for duration extraction
   - Edge cases: empty strings, unicode, whitespace, invalid inputs
   - Integration tests: all difficulty/duration combinations

### Issue #24 Checklist

- [x] Difficulty-based term explanation levels
- [x] Duration-based detail levels
- [ ] Feedback-based tone adjustment (deferred - requires feedback storage infrastructure)

### Test Results

```
102 passed, 12 warnings in 0.84s
```

All tests passing. Warnings are harmless Pydantic deprecations in dependencies.

### Backward Compatibility

- Default `tone_agent` export unchanged
- Existing code using `tone_agent` continues to work
- New personalization is opt-in via `create_tone_editor_agent()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)