### PR TITLE
feat(web): scheduled newsletter delivery with immediate-generate option (#32)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=wndekztdanvcvjulfknl&read_only=true"
+    }
+  }
+}

--- a/flow-diagram/email-flow.mmd
+++ b/flow-diagram/email-flow.mmd
@@ -1,0 +1,86 @@
+---
+title: Newsletter Email Flow — from 제출하기 to Inbox
+---
+sequenceDiagram
+    autonumber
+    participant Browser as Browser<br/>(questions/[topicId]/page.tsx)
+    participant NextAPI as Next.js API Route<br/>(app/api/newsletters/[id]/send)
+    participant Action as Server Action<br/>(lib/actions/newsletter.ts)
+    participant SendUtil as sendUnsentNewsletter()<br/>(lib/email/send-newsletter.ts)
+    participant Resend as sendNewsletterEmail()<br/>(lib/email/resend.ts)
+    participant ResendAPI as Resend API<br/>(External)
+    participant FastAPI as FastAPI<br/>(api/main.py — /generate/stream)
+    participant Generator as NewsletterGenerator<br/>(src/api/newsletter_generator.py)
+    participant DB as Supabase<br/>(PostgreSQL)
+    participant Inbox as User's Email Inbox
+
+    rect rgb(230, 240, 255)
+        Note over Browser,DB: Phase 1 — Answer Submission & Preference Save
+        Browser->>+Action: saveAnswers(topicId, answers)
+        Action->>+DB: INSERT answers INTO user_answers
+        DB-->>-Action: OK
+        Action-->>-Browser: { success: true }
+
+        Browser->>+Action: saveDeliveryPreference(selectedDay)
+        Action->>+DB: UPSERT delivery_preferences
+        DB-->>-Action: OK
+        Action-->>-Browser: { success: true }
+    end
+
+    rect rgb(230, 255, 230)
+        Note over Browser,DB: Phase 2 — Newsletter Generation (SSE Streaming)
+        Browser->>+FastAPI: POST /api/newsletter/generate/stream<br/>{ user_id, topic_id }
+        FastAPI->>+Generator: generate_newsletter_stream(user_id, topic_id)
+
+        Generator->>+DB: create_newsletter_request() — status: pending
+        DB-->>-Generator: request_id
+        Generator->>+DB: update_request_status() — status: processing
+        DB-->>-Generator: OK
+
+        Generator->>+DB: get_topic_and_answers(topic_id)
+        DB-->>-Generator: topic + personalization answers
+
+        Note over Generator: Run LangGraph deep agents<br/>(research → topic_selector → tone_editor)
+        Generator->>Generator: Research agent collects news (Tavily / HN)
+        Generator->>Generator: Topic selector picks themes
+        Generator->>Generator: Tone editor refines to Automata style
+
+        Generator->>+DB: save_newsletter() — is_published: true
+        DB-->>-Generator: newsletter_id
+        Generator->>+DB: update_request_status() — status: completed
+        DB-->>-Generator: OK
+
+        Generator-->>-FastAPI: SSE event { step: "complete", newsletter_id }
+        FastAPI-->>-Browser: SSE event { step: "complete", newsletter_id }
+    end
+
+    rect rgb(255, 240, 220)
+        Note over Browser,DB: Phase 3 — Trigger Email Send
+        Browser->>+NextAPI: POST /api/newsletters/{newsletterId}/send
+        NextAPI->>+DB: Verify auth (supabase.auth.getUser)
+        DB-->>-NextAPI: user session
+        NextAPI->>+DB: SELECT newsletter JOIN user_topics<br/>WHERE id = newsletterId AND user_id = user.id
+        DB-->>-NextAPI: newsletter record + topic_text
+
+        NextAPI->>NextAPI: Guard checks:<br/>— already sent? (email_sent_at IS NULL)<br/>— topic within 4-week window?
+    end
+
+    rect rgb(255, 230, 230)
+        Note over NextAPI,Inbox: Phase 4 — Email Delivery via Resend
+        NextAPI->>+Resend: sendNewsletterEmail()<br/>{ userEmail, topic, newsletterId, newsletterUrl }
+        Resend->>Resend: render(NewsletterEmail) — React Email template
+        Resend->>+ResendAPI: resend.emails.send()<br/>from: newsletter@automata.com<br/>to: user email<br/>subject: 이번 주 {topic}에 대한 뉴스레터가 완성되었어요
+        ResendAPI-->>-Resend: { id: emailId }
+        Resend-->>-NextAPI: { success: true, id: emailId }
+
+        NextAPI->>+DB: UPDATE newsletters SET email_sent_at = now()
+        DB-->>-NextAPI: OK
+        NextAPI->>+DB: INSERT email_events (event_type: sent,<br/>email_provider: resend, email_provider_id: emailId)
+        DB-->>-NextAPI: OK
+        NextAPI-->>Browser: { success: true, emailId, sentAt }
+
+        ResendAPI-->>Inbox: Email delivered
+    end
+
+    Browser->>Browser: toast.success('이메일이 발송되었습니다!')
+    Browser->>Browser: router.push(/newsletter/{newsletterId})

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -2,7 +2,7 @@
 
 from .research import research_subagent, create_research_subagent
 from .topic_selector import topic_selection_agent, create_topic_selector_subagent
-from .tone_editor import tone_agent
+from .tone_editor import tone_agent, create_tone_editor_agent
 
 __all__ = [
     "research_subagent",

--- a/src/api/newsletter_generator.py
+++ b/src/api/newsletter_generator.py
@@ -8,7 +8,7 @@ from deepagents import create_deep_agent
 from langsmith import Client as LangSmithClient
 
 from ..config import ANTHROPIC_API_KEY, TAVILY_API_KEY
-from ..agents import create_research_subagent, create_topic_selector_subagent, tone_agent
+from ..agents import create_research_subagent, create_topic_selector_subagent, create_tone_editor_agent
 from .models import (
     NewsletterContext,
     ProgressUpdate,
@@ -249,11 +249,17 @@ class NewsletterGenerator:
             # Create personalized topic selector agent
             topic_selector = create_topic_selector_subagent(research_context)
 
+            # Create personalized tone editor agent
+            tone_editor = create_tone_editor_agent(
+                difficulty=research_context.get("difficulty"),
+                duration=research_context.get("duration"),
+            )
+
             # Create agent
             agent = create_deep_agent(
                 system_prompt="You are an expert research newsletter writer. Follow the user's instructions carefully and produce high-quality, well-researched content.",
                 tools=[],  # No tools needed, subagents have them
-                subagents=[research_agent, topic_selector, tone_agent],
+                subagents=[research_agent, topic_selector, tone_editor],
             )
 
             # Configure LangSmith metadata
@@ -398,7 +404,7 @@ class NewsletterGenerator:
             agent = create_deep_agent(
                 system_prompt="You are an expert research newsletter writer. Follow the user's instructions carefully and produce high-quality, well-researched content.",
                 tools=[],
-                subagents=[research_agent, topic_selection_agent, tone_editor],
+                subagents=[research_agent, topic_selector, tone_editor],
             )
 
             config: Dict[str, Any] = {

--- a/src/api/supabase_client.py
+++ b/src/api/supabase_client.py
@@ -208,7 +208,7 @@ class SupabaseClient:
             "body": content.body,
             "word_count": content.word_count,
             "estimated_reading_time": content.estimated_reading_time,
-            "is_published": False,  # Not published yet
+            "is_published": True,
             "created_at": datetime.utcnow().isoformat(),
         }
 

--- a/supabase/migrations/20260203000000_add_scheduled_delivery.sql
+++ b/supabase/migrations/20260203000000_add_scheduled_delivery.sql
@@ -1,0 +1,18 @@
+-- Migration: Add scheduled delivery question types
+-- Created: 2026-02-03
+-- Description: Adds 'delivery_day' and 'generate_now' to allowed question_type values
+--              to support the scheduled newsletter delivery feature (Issue #32)
+
+BEGIN;
+
+-- Drop existing constraint
+ALTER TABLE personalization_questions
+DROP CONSTRAINT personalization_questions_type_check;
+
+-- Re-create with new allowed types
+ALTER TABLE personalization_questions
+ADD CONSTRAINT personalization_questions_type_check CHECK (
+    question_type IN ('goal', 'difficulty', 'scope', 'time', 'source', 'subtopic', 'custom', 'delivery_day', 'generate_now')
+);
+
+COMMIT;

--- a/vercel.json
+++ b/vercel.json
@@ -15,5 +15,11 @@
       "src": "/api/(.*)",
       "dest": "api/main.py"
     }
+  ],
+  "crons": [
+    {
+      "path": "/api/cron/send-newsletters",
+      "schedule": "0 0 * * *"
+    }
   ]
 }

--- a/web/__tests__/app/api/cron/send-newsletters.test.ts
+++ b/web/__tests__/app/api/cron/send-newsletters.test.ts
@@ -42,7 +42,10 @@ function newslettersPhase1(unsent: { id: string }[] = []) {
 /**
  * user_preferences SELECT chain (Phase 2, first query).
  */
-function preferencesChain(data: { user_id: string }[] | null, error = null) {
+function preferencesChain(
+  data: { user_id: string }[] | null,
+  error: { message: string } | null = null
+) {
   return {
     select: vi.fn().mockReturnValue({
       eq: vi.fn().mockReturnValue({
@@ -59,7 +62,7 @@ function preferencesChain(data: { user_id: string }[] | null, error = null) {
  */
 function topicsChain(
   data: { id: string; user_id: string }[] | null,
-  error = null
+  error: { message: string } | null = null
 ) {
   return {
     select: vi.fn().mockReturnValue({

--- a/web/__tests__/app/api/cron/send-newsletters.test.ts
+++ b/web/__tests__/app/api/cron/send-newsletters.test.ts
@@ -9,11 +9,66 @@ vi.mock('@/lib/supabase/server', () => ({
   })),
 }));
 
+const mockSendUnsentNewsletter = vi.fn();
+vi.mock('@/lib/email/send-newsletter', () => ({
+  sendUnsentNewsletter: (...args: unknown[]) =>
+    mockSendUnsentNewsletter(...args),
+}));
+
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
 vi.stubEnv('CRON_SECRET', 'test-cron-secret');
 vi.stubEnv('NEXT_PUBLIC_API_URL', 'http://localhost:8000');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Default Phase-1 mock: no unsent newsletters.
+ * Returns the newsletters SELECT chain that resolves to { data: [], error: null }.
+ */
+function newslettersPhase1(unsent: { id: string }[] = []) {
+  return {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        is: vi.fn().mockResolvedValue({ data: unsent, error: null }),
+      }),
+    }),
+  };
+}
+
+/**
+ * user_preferences SELECT chain (Phase 2, first query).
+ */
+function preferencesChain(data: { user_id: string }[] | null, error = null) {
+  return {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data, error }),
+        }),
+      }),
+    }),
+  };
+}
+
+/**
+ * user_topics SELECT chain (Phase 2, second query).
+ */
+function topicsChain(
+  data: { id: string; user_id: string }[] | null,
+  error = null
+) {
+  return {
+    select: vi.fn().mockReturnValue({
+      in: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data, error }),
+      }),
+    }),
+  };
+}
 
 describe('GET /api/cron/send-newsletters', () => {
   beforeEach(() => {
@@ -26,6 +81,9 @@ describe('GET /api/cron/send-newsletters', () => {
       headers: authToken ? { authorization: `Bearer ${authToken}` } : {},
     });
 
+  // -----------------------------------------------------------------------
+  // Auth guards
+  // -----------------------------------------------------------------------
   it('should return 401 without authorization header', async () => {
     const response = await GET(makeRequest());
     const data = await response.json();
@@ -42,18 +100,15 @@ describe('GET /api/cron/send-newsletters', () => {
     expect(data.error).toBe('Unauthorized');
   });
 
+  // -----------------------------------------------------------------------
+  // Phase 2 – existing scenarios (Phase 1 returns empty unsent list)
+  // -----------------------------------------------------------------------
   it('should return message when no users are scheduled for tomorrow', async () => {
-    mockFrom.mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({
-              data: [],
-              error: null,
-            }),
-          }),
-        }),
-      }),
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return newslettersPhase1();
+      return preferencesChain([]);
     });
 
     const response = await GET(makeRequest('test-cron-secret'));
@@ -61,20 +116,15 @@ describe('GET /api/cron/send-newsletters', () => {
 
     expect(response.status).toBe(200);
     expect(data.message).toBe('No users scheduled for tomorrow');
+    expect(data.emails).toEqual({ sent: 0, alreadySent: 0, failed: 0 });
   });
 
   it('should return 500 when fetching preferences fails', async () => {
-    mockFrom.mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({
-              data: null,
-              error: { message: 'DB error' },
-            }),
-          }),
-        }),
-      }),
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return newslettersPhase1();
+      return preferencesChain(null, { message: 'DB error' });
     });
 
     const response = await GET(makeRequest('test-cron-secret'));
@@ -88,30 +138,9 @@ describe('GET /api/cron/send-newsletters', () => {
     let callCount = 0;
     mockFrom.mockImplementation(() => {
       callCount++;
-      if (callCount === 1) {
-        return {
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                eq: vi.fn().mockResolvedValue({
-                  data: [{ user_id: 'user-1' }],
-                  error: null,
-                }),
-              }),
-            }),
-          }),
-        };
-      }
-      return {
-        select: vi.fn().mockReturnValue({
-          in: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({
-              data: [],
-              error: null,
-            }),
-          }),
-        }),
-      };
+      if (callCount === 1) return newslettersPhase1();
+      if (callCount === 2) return preferencesChain([{ user_id: 'user-1' }]);
+      return topicsChain([]);
     });
 
     const response = await GET(makeRequest('test-cron-secret'));
@@ -119,39 +148,20 @@ describe('GET /api/cron/send-newsletters', () => {
 
     expect(response.status).toBe(200);
     expect(data.message).toBe('No active topics found');
+    expect(data.emails).toEqual({ sent: 0, alreadySent: 0, failed: 0 });
   });
 
   it('should trigger generation for each topic and return results', async () => {
     let callCount = 0;
     mockFrom.mockImplementation(() => {
       callCount++;
-      if (callCount === 1) {
-        return {
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                eq: vi.fn().mockResolvedValue({
-                  data: [{ user_id: 'user-1' }, { user_id: 'user-2' }],
-                  error: null,
-                }),
-              }),
-            }),
-          }),
-        };
-      }
-      return {
-        select: vi.fn().mockReturnValue({
-          in: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({
-              data: [
-                { id: 'topic-1', user_id: 'user-1' },
-                { id: 'topic-2', user_id: 'user-2' },
-              ],
-              error: null,
-            }),
-          }),
-        }),
-      };
+      if (callCount === 1) return newslettersPhase1();
+      if (callCount === 2)
+        return preferencesChain([{ user_id: 'user-1' }, { user_id: 'user-2' }]);
+      return topicsChain([
+        { id: 'topic-1', user_id: 'user-1' },
+        { id: 'topic-2', user_id: 'user-2' },
+      ]);
     });
 
     mockFetch.mockResolvedValue({
@@ -180,33 +190,12 @@ describe('GET /api/cron/send-newsletters', () => {
     let callCount = 0;
     mockFrom.mockImplementation(() => {
       callCount++;
-      if (callCount === 1) {
-        return {
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                eq: vi.fn().mockResolvedValue({
-                  data: [{ user_id: 'user-1' }],
-                  error: null,
-                }),
-              }),
-            }),
-          }),
-        };
-      }
-      return {
-        select: vi.fn().mockReturnValue({
-          in: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({
-              data: [
-                { id: 'topic-ok', user_id: 'user-1' },
-                { id: 'topic-fail', user_id: 'user-1' },
-              ],
-              error: null,
-            }),
-          }),
-        }),
-      };
+      if (callCount === 1) return newslettersPhase1();
+      if (callCount === 2) return preferencesChain([{ user_id: 'user-1' }]);
+      return topicsChain([
+        { id: 'topic-ok', user_id: 'user-1' },
+        { id: 'topic-fail', user_id: 'user-1' },
+      ]);
     });
 
     mockFetch
@@ -224,30 +213,9 @@ describe('GET /api/cron/send-newsletters', () => {
     let callCount = 0;
     mockFrom.mockImplementation(() => {
       callCount++;
-      if (callCount === 1) {
-        return {
-          select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              eq: vi.fn().mockReturnValue({
-                eq: vi.fn().mockResolvedValue({
-                  data: [{ user_id: 'user-1' }],
-                  error: null,
-                }),
-              }),
-            }),
-          }),
-        };
-      }
-      return {
-        select: vi.fn().mockReturnValue({
-          in: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({
-              data: null,
-              error: { message: 'Topics DB error' },
-            }),
-          }),
-        }),
-      };
+      if (callCount === 1) return newslettersPhase1();
+      if (callCount === 2) return preferencesChain([{ user_id: 'user-1' }]);
+      return topicsChain(null, { message: 'Topics DB error' });
     });
 
     const response = await GET(makeRequest('test-cron-secret'));
@@ -255,5 +223,52 @@ describe('GET /api/cron/send-newsletters', () => {
 
     expect(response.status).toBe(500);
     expect(data.error).toBe('Failed to fetch topics');
+  });
+
+  // -----------------------------------------------------------------------
+  // Phase 1 – send unsent newsletters
+  // -----------------------------------------------------------------------
+  it('should send unsent newsletters before triggering generation', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1)
+        return newslettersPhase1([{ id: 'nl-1' }, { id: 'nl-2' }]);
+      // Phase 2: no users scheduled → early return after email phase
+      return preferencesChain([]);
+    });
+
+    mockSendUnsentNewsletter
+      .mockResolvedValueOnce({ success: true, emailId: 'email-1' })
+      .mockResolvedValueOnce({ success: true, emailId: 'email-2' });
+
+    const response = await GET(makeRequest('test-cron-secret'));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockSendUnsentNewsletter).toHaveBeenCalledTimes(2);
+    expect(mockSendUnsentNewsletter).toHaveBeenCalledWith('nl-1');
+    expect(mockSendUnsentNewsletter).toHaveBeenCalledWith('nl-2');
+    expect(data.emails).toEqual({ sent: 2, alreadySent: 0, failed: 0 });
+  });
+
+  it('should skip already-sent newsletters in the send-unsent phase', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1)
+        return newslettersPhase1([{ id: 'nl-sent' }, { id: 'nl-new' }]);
+      return preferencesChain([]);
+    });
+
+    mockSendUnsentNewsletter
+      .mockResolvedValueOnce({ success: false, alreadySent: true })
+      .mockResolvedValueOnce({ success: true, emailId: 'email-new' });
+
+    const response = await GET(makeRequest('test-cron-secret'));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.emails).toEqual({ sent: 1, alreadySent: 1, failed: 0 });
   });
 });

--- a/web/__tests__/app/api/cron/send-newsletters.test.ts
+++ b/web/__tests__/app/api/cron/send-newsletters.test.ts
@@ -23,9 +23,7 @@ describe('GET /api/cron/send-newsletters', () => {
   const makeRequest = (authToken?: string) =>
     new Request('http://localhost:3000/api/cron/send-newsletters', {
       method: 'GET',
-      headers: authToken
-        ? { authorization: `Bearer ${authToken}` }
-        : {},
+      headers: authToken ? { authorization: `Bearer ${authToken}` } : {},
     });
 
   it('should return 401 without authorization header', async () => {

--- a/web/__tests__/app/api/cron/send-newsletters.test.ts
+++ b/web/__tests__/app/api/cron/send-newsletters.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET } from '@/app/api/cron/send-newsletters/route';
+
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createAdminClient: vi.fn(() => ({
+    from: mockFrom,
+  })),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+vi.stubEnv('CRON_SECRET', 'test-cron-secret');
+vi.stubEnv('NEXT_PUBLIC_API_URL', 'http://localhost:8000');
+
+describe('GET /api/cron/send-newsletters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const makeRequest = (authToken?: string) =>
+    new Request('http://localhost:3000/api/cron/send-newsletters', {
+      method: 'GET',
+      headers: authToken
+        ? { authorization: `Bearer ${authToken}` }
+        : {},
+    });
+
+  it('should return 401 without authorization header', async () => {
+    const response = await GET(makeRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('Unauthorized');
+  });
+
+  it('should return 401 with invalid CRON_SECRET', async () => {
+    const response = await GET(makeRequest('wrong-secret'));
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe('Unauthorized');
+  });
+
+  it('should return message when no users are scheduled for tomorrow', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    });
+
+    const response = await GET(makeRequest('test-cron-secret'));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.message).toBe('No users scheduled for tomorrow');
+  });
+
+  it('should return 500 when fetching preferences fails', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: 'DB error' },
+            }),
+          }),
+        }),
+      }),
+    });
+
+    const response = await GET(makeRequest('test-cron-secret'));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to fetch preferences');
+  });
+
+  it('should return message when users found but no active topics', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockResolvedValue({
+                  data: [{ user_id: 'user-1' }],
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          in: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+          }),
+        }),
+      };
+    });
+
+    const response = await GET(makeRequest('test-cron-secret'));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.message).toBe('No active topics found');
+  });
+
+  it('should trigger generation for each topic and return results', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockResolvedValue({
+                  data: [{ user_id: 'user-1' }, { user_id: 'user-2' }],
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          in: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { id: 'topic-1', user_id: 'user-1' },
+                { id: 'topic-2', user_id: 'user-2' },
+              ],
+              error: null,
+            }),
+          }),
+        }),
+      };
+    });
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ request_id: 'req-1' }),
+    });
+
+    const response = await GET(makeRequest('test-cron-secret'));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.topics_triggered).toBe(2);
+    expect(data.fulfilled).toBe(2);
+    expect(data.rejected).toBe(0);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/newsletter/generate',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ user_id: 'user-1', topic_id: 'topic-1' }),
+      })
+    );
+  });
+
+  it('should count rejected promises when generation fails for some topics', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockResolvedValue({
+                  data: [{ user_id: 'user-1' }],
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          in: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { id: 'topic-ok', user_id: 'user-1' },
+                { id: 'topic-fail', user_id: 'user-1' },
+              ],
+              error: null,
+            }),
+          }),
+        }),
+      };
+    });
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const response = await GET(makeRequest('test-cron-secret'));
+    const data = await response.json();
+
+    expect(data.fulfilled).toBe(1);
+    expect(data.rejected).toBe(1);
+  });
+
+  it('should return 500 when fetching topics fails', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockResolvedValue({
+                  data: [{ user_id: 'user-1' }],
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          in: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: 'Topics DB error' },
+            }),
+          }),
+        }),
+      };
+    });
+
+    const response = await GET(makeRequest('test-cron-secret'));
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe('Failed to fetch topics');
+  });
+});

--- a/web/__tests__/components/topic-input.test.tsx
+++ b/web/__tests__/components/topic-input.test.tsx
@@ -45,7 +45,7 @@ describe('TopicInput', () => {
   it('should render input field with placeholder', () => {
     render(<TopicInput value="" onChange={mockOnChange} />);
 
-    const input = screen.getByPlaceholderText('어떤 주제로 리서치해 드릴까요?');
+    const input = screen.getByTestId('topic-input');
     expect(input).toBeInTheDocument();
   });
 
@@ -76,7 +76,7 @@ describe('TopicInput', () => {
     const user = userEvent.setup();
     render(<TopicInput value="" onChange={mockOnChange} />);
 
-    const input = screen.getByPlaceholderText('어떤 주제로 리서치해 드릴까요?');
+    const input = screen.getByTestId('topic-input');
     await user.type(input, 'AI 에이전트');
 
     expect(mockOnChange).toHaveBeenCalled();
@@ -188,7 +188,7 @@ describe('TopicInput', () => {
       <TopicInput value="AI 에이전트 최신 동향" onChange={mockOnChange} />
     );
 
-    const input = screen.getByPlaceholderText('어떤 주제로 리서치해 드릴까요?');
+    const input = screen.getByTestId('topic-input');
     const submitButton = screen.getByText('리서치 시작하기');
 
     await user.click(submitButton);
@@ -215,9 +215,7 @@ describe('TopicInput', () => {
   it('should enforce max length of 100 characters', () => {
     render(<TopicInput value="" onChange={mockOnChange} />);
 
-    const input = screen.getByPlaceholderText(
-      '어떤 주제로 리서치해 드릴까요?'
-    ) as HTMLInputElement;
+    const input = screen.getByTestId('topic-input') as HTMLInputElement;
     expect(input.maxLength).toBe(100);
   });
 

--- a/web/__tests__/lib/actions/newsletter-email.test.ts
+++ b/web/__tests__/lib/actions/newsletter-email.test.ts
@@ -1,15 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { sendNewsletterEmail } from '@/lib/actions/newsletter';
+import { sendUnsentNewsletter } from '@/lib/email/send-newsletter';
 
-// Mock env
-vi.mock('@/lib/env', () => ({
-  env: {
-    NEXT_PUBLIC_SITE_URL: 'https://example.com',
-  },
+vi.mock('@/lib/email/send-newsletter', () => ({
+  sendUnsentNewsletter: vi.fn(),
 }));
-
-// Mock fetch
-global.fetch = vi.fn();
 
 describe('sendNewsletterEmail server action', () => {
   const mockNewsletterId = 'newsletter-123';
@@ -19,14 +14,9 @@ describe('sendNewsletterEmail server action', () => {
   });
 
   it('should send email successfully', async () => {
-    (global.fetch as any).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        success: true,
-        message: '이메일이 성공적으로 발송되었습니다.',
-        emailId: 'email-123',
-        sentAt: '2026-01-01T00:00:00Z',
-      }),
+    vi.mocked(sendUnsentNewsletter).mockResolvedValueOnce({
+      success: true,
+      emailId: 'email-123',
     });
 
     const result = await sendNewsletterEmail(mockNewsletterId);
@@ -34,24 +24,14 @@ describe('sendNewsletterEmail server action', () => {
     expect(result.success).toBe(true);
     expect(result.message).toContain('성공적으로 발송');
     expect(result.emailId).toBe('email-123');
-    expect(result.sentAt).toBe('2026-01-01T00:00:00Z');
-    expect(global.fetch).toHaveBeenCalledWith(
-      `https://example.com/api/newsletters/${mockNewsletterId}/send`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
-    );
+    expect(result.sentAt).toBeDefined();
+    expect(sendUnsentNewsletter).toHaveBeenCalledWith(mockNewsletterId);
   });
 
-  it('should handle API error', async () => {
-    (global.fetch as any).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({
-        message: '이메일 발송에 실패했습니다.',
-      }),
+  it('should handle send failure', async () => {
+    vi.mocked(sendUnsentNewsletter).mockResolvedValueOnce({
+      success: false,
+      error: '이메일 발송에 실패했습니다.',
     });
 
     const result = await sendNewsletterEmail(mockNewsletterId);
@@ -61,7 +41,9 @@ describe('sendNewsletterEmail server action', () => {
   });
 
   it('should handle network error', async () => {
-    (global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
+    vi.mocked(sendUnsentNewsletter).mockRejectedValueOnce(
+      new Error('Network error')
+    );
 
     const result = await sendNewsletterEmail(mockNewsletterId);
 
@@ -69,18 +51,15 @@ describe('sendNewsletterEmail server action', () => {
     expect(result.message).toContain('오류가 발생');
   });
 
-  it('should use default message when API message is missing', async () => {
-    (global.fetch as any).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        success: true,
-        emailId: 'email-123',
-      }),
+  it('should handle already sent newsletter', async () => {
+    vi.mocked(sendUnsentNewsletter).mockResolvedValueOnce({
+      success: false,
+      alreadySent: true,
     });
 
     const result = await sendNewsletterEmail(mockNewsletterId);
 
     expect(result.success).toBe(true);
-    expect(result.message).toBe('이메일이 성공적으로 발송되었습니다.');
+    expect(result.message).toBe('이미 발송된 뉴스레터입니다.');
   });
 });

--- a/web/__tests__/lib/actions/preference.test.ts
+++ b/web/__tests__/lib/actions/preference.test.ts
@@ -28,7 +28,9 @@ describe('saveDeliveryPreference', () => {
     });
     mockSelect.mockReturnValue({ eq: mockEq });
     mockEq.mockReturnValue({ maybeSingle: mockMaybeSingle });
-    mockUpdate.mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    mockUpdate.mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    });
   });
 
   it('should return error when not authenticated', async () => {
@@ -103,7 +105,9 @@ describe('saveDeliveryPreference', () => {
     });
     mockMaybeSingle.mockResolvedValue({ data: { id: 'pref-1' } });
 
-    const mockUpdateEq = vi.fn().mockResolvedValue({ error: { message: 'DB error' } });
+    const mockUpdateEq = vi
+      .fn()
+      .mockResolvedValue({ error: { message: 'DB error' } });
     mockUpdate.mockReturnValue({ eq: mockUpdateEq });
 
     const result = await saveDeliveryPreference('금요일');
@@ -135,13 +139,13 @@ describe('saveDeliveryPreference', () => {
     mockInsert.mockResolvedValue({ error: null });
 
     const dayMap: Record<string, number> = {
-      '월요일': 1,
-      '화요일': 2,
-      '수요일': 3,
-      '목요일': 4,
-      '금요일': 5,
-      '토요일': 6,
-      '일요일': 0,
+      월요일: 1,
+      화요일: 2,
+      수요일: 3,
+      목요일: 4,
+      금요일: 5,
+      토요일: 6,
+      일요일: 0,
     };
 
     for (const [dayName, expectedInt] of Object.entries(dayMap)) {

--- a/web/__tests__/lib/actions/preference.test.ts
+++ b/web/__tests__/lib/actions/preference.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { saveDeliveryPreference } from '@/lib/actions/preference';
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockMaybeSingle = vi.fn();
+const mockUpdate = vi.fn();
+const mockInsert = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      getUser: mockGetUser,
+    },
+    from: mockFrom,
+  })),
+}));
+
+describe('saveDeliveryPreference', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFrom.mockReturnValue({
+      select: mockSelect,
+      update: mockUpdate,
+      insert: mockInsert,
+    });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ maybeSingle: mockMaybeSingle });
+    mockUpdate.mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+  });
+
+  it('should return error when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'Not authenticated' },
+    });
+
+    const result = await saveDeliveryPreference('월요일');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('로그인이 필요합니다.');
+  });
+
+  it('should return error for invalid day name', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1' } },
+      error: null,
+    });
+
+    const result = await saveDeliveryPreference('잘못된요일');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('올바르지 않은 요일입니다.');
+  });
+
+  it('should update existing preference when row exists', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1' } },
+      error: null,
+    });
+    mockMaybeSingle.mockResolvedValue({ data: { id: 'pref-1' } });
+
+    const mockUpdateEq = vi.fn().mockResolvedValue({ error: null });
+    mockUpdate.mockReturnValue({ eq: mockUpdateEq });
+
+    const result = await saveDeliveryPreference('월요일');
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe('발송 주기가 저장되었습니다.');
+    expect(mockUpdate).toHaveBeenCalledWith({
+      send_frequency: 'weekly',
+      preferred_send_day: 1,
+      preferred_send_time: '09:00:00',
+    });
+    expect(mockUpdateEq).toHaveBeenCalledWith('user_id', 'user-1');
+  });
+
+  it('should insert new preference when row does not exist', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1' } },
+      error: null,
+    });
+    mockMaybeSingle.mockResolvedValue({ data: null });
+    mockInsert.mockResolvedValue({ error: null });
+
+    const result = await saveDeliveryPreference('수요일');
+
+    expect(result.success).toBe(true);
+    expect(mockInsert).toHaveBeenCalledWith({
+      user_id: 'user-1',
+      send_frequency: 'weekly',
+      preferred_send_day: 3,
+      preferred_send_time: '09:00:00',
+    });
+  });
+
+  it('should return error when update fails', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1' } },
+      error: null,
+    });
+    mockMaybeSingle.mockResolvedValue({ data: { id: 'pref-1' } });
+
+    const mockUpdateEq = vi.fn().mockResolvedValue({ error: { message: 'DB error' } });
+    mockUpdate.mockReturnValue({ eq: mockUpdateEq });
+
+    const result = await saveDeliveryPreference('금요일');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('발송 주기 저장에 실패했습니다.');
+  });
+
+  it('should return error when insert fails', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1' } },
+      error: null,
+    });
+    mockMaybeSingle.mockResolvedValue({ data: null });
+    mockInsert.mockResolvedValue({ error: { message: 'DB error' } });
+
+    const result = await saveDeliveryPreference('토요일');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('발송 주기 저장에 실패했습니다.');
+  });
+
+  it('should map all days correctly', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1' } },
+      error: null,
+    });
+    mockMaybeSingle.mockResolvedValue({ data: null });
+    mockInsert.mockResolvedValue({ error: null });
+
+    const dayMap: Record<string, number> = {
+      '월요일': 1,
+      '화요일': 2,
+      '수요일': 3,
+      '목요일': 4,
+      '금요일': 5,
+      '토요일': 6,
+      '일요일': 0,
+    };
+
+    for (const [dayName, expectedInt] of Object.entries(dayMap)) {
+      mockInsert.mockClear();
+      const result = await saveDeliveryPreference(dayName);
+      expect(result.success).toBe(true);
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({ preferred_send_day: expectedInt })
+      );
+    }
+  });
+});

--- a/web/__tests__/lib/email/send-newsletter.test.ts
+++ b/web/__tests__/lib/email/send-newsletter.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { sendUnsentNewsletter } from '@/lib/email/send-newsletter';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+const mockFrom = vi.fn();
+const mockGetUserById = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createAdminClient: vi.fn(() => ({
+    from: mockFrom,
+    auth: { admin: { getUserById: mockGetUserById } },
+  })),
+}));
+
+const mockSendNewsletterEmail = vi.fn();
+vi.mock('@/lib/email/resend', () => ({
+  sendNewsletterEmail: (...args: unknown[]) => mockSendNewsletterEmail(...args),
+}));
+
+vi.mock('@/lib/env', () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon-key',
+    SUPABASE_SERVICE_ROLE_KEY: 'service-key',
+    RESEND_API_KEY: 'resend-key',
+    API_SECRET_KEY: 'a'.repeat(32),
+    NEXT_PUBLIC_SITE_URL: 'http://localhost:3000',
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const NEWSLETTER_ID = 'nl-1';
+const USER_ID = 'user-1';
+const USER_EMAIL = 'user@example.com';
+const TOPIC_TEXT = 'AI 에이전트';
+
+/** Returns a newsletter row with sane defaults. */
+function makeNewsletter(overrides: Record<string, unknown> = {}) {
+  return {
+    id: NEWSLETTER_ID,
+    user_id: USER_ID,
+    topic_id: 'topic-1',
+    email_sent_at: null,
+    user_topics: {
+      topic_text: TOPIC_TEXT,
+      created_at: new Date().toISOString(), // now → well within 4-week window
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Wire up mockFrom so that:
+ *   call 1 (.from('newsletters').select...single) → { data: newsletter, error }
+ *   call 2+ (.from('newsletters').update / .from('email_events').insert) → { error: null }
+ */
+function mockNewsletterQuery(
+  newsletter: ReturnType<typeof makeNewsletter> | null,
+  error: unknown = null
+) {
+  let callCount = 0;
+  mockFrom.mockImplementation(() => {
+    callCount++;
+    if (callCount === 1) {
+      // newsletters SELECT … single
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: newsletter,
+              error,
+            }),
+          }),
+        }),
+      };
+    }
+    // newsletters UPDATE or email_events INSERT
+    return {
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('sendUnsentNewsletter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('successfully sends email and updates email_sent_at', async () => {
+    mockNewsletterQuery(makeNewsletter());
+    mockGetUserById.mockResolvedValue({
+      data: { user: { email: USER_EMAIL } },
+      error: null,
+    });
+    mockSendNewsletterEmail.mockResolvedValue({ success: true, id: 'email-1' });
+
+    const result = await sendUnsentNewsletter(NEWSLETTER_ID);
+
+    expect(result).toEqual({ success: true, emailId: 'email-1' });
+    expect(mockSendNewsletterEmail).toHaveBeenCalledWith({
+      userEmail: USER_EMAIL,
+      topic: TOPIC_TEXT,
+      newsletterId: NEWSLETTER_ID,
+      newsletterUrl: `http://localhost:3000/newsletter/${NEWSLETTER_ID}`,
+    });
+  });
+
+  it('returns alreadySent when email_sent_at is set', async () => {
+    mockNewsletterQuery(
+      makeNewsletter({ email_sent_at: '2026-01-01T00:00:00.000Z' })
+    );
+
+    const result = await sendUnsentNewsletter(NEWSLETTER_ID);
+
+    expect(result).toEqual({ success: false, alreadySent: true });
+    expect(mockSendNewsletterEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns error when newsletter not found', async () => {
+    mockNewsletterQuery(null);
+
+    const result = await sendUnsentNewsletter(NEWSLETTER_ID);
+
+    expect(result).toEqual({ success: false, error: 'Newsletter not found' });
+    expect(mockSendNewsletterEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns error when user email lookup fails', async () => {
+    mockNewsletterQuery(makeNewsletter());
+    mockGetUserById.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'User not found' },
+    });
+
+    const result = await sendUnsentNewsletter(NEWSLETTER_ID);
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Failed to fetch user email',
+    });
+    expect(mockSendNewsletterEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns error when Resend fails and logs failed event', async () => {
+    mockNewsletterQuery(makeNewsletter());
+    mockGetUserById.mockResolvedValue({
+      data: { user: { email: USER_EMAIL } },
+      error: null,
+    });
+    mockSendNewsletterEmail.mockResolvedValue({
+      success: false,
+      id: '',
+      error: 'Resend API error',
+    });
+
+    const result = await sendUnsentNewsletter(NEWSLETTER_ID);
+
+    expect(result).toEqual({ success: false, error: 'Resend API error' });
+
+    // Verify the failed event was inserted (second mockFrom call)
+    const insertCall = mockFrom.mock.calls.find(
+      (call: string[]) => call[0] === 'email_events'
+    );
+    expect(insertCall).toBeDefined();
+  });
+
+  it('skips send when topic exceeds 4-week limit', async () => {
+    const fiveWeeksAgo = new Date(
+      Date.now() - 5 * 7 * 24 * 60 * 60 * 1000
+    ).toISOString();
+
+    mockNewsletterQuery(
+      makeNewsletter({
+        user_topics: { topic_text: TOPIC_TEXT, created_at: fiveWeeksAgo },
+      })
+    );
+
+    const result = await sendUnsentNewsletter(NEWSLETTER_ID);
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Topic exceeded 4-week limit',
+    });
+    expect(mockSendNewsletterEmail).not.toHaveBeenCalled();
+  });
+
+  it('handles DB errors gracefully when newsletter query errors', async () => {
+    mockNewsletterQuery(null, { message: 'Connection refused' });
+
+    const result = await sendUnsentNewsletter(NEWSLETTER_ID);
+
+    expect(result).toEqual({ success: false, error: 'Newsletter not found' });
+  });
+});

--- a/web/__tests__/lib/validation/question.test.ts
+++ b/web/__tests__/lib/validation/question.test.ts
@@ -339,7 +339,10 @@ describe('Question Validation Schemas', () => {
 
     it('should validate generate_now checkbox answer', () => {
       const question = createQuestion('generate_now', false);
-      const answer: Answer = { type: 'checkbox', value: ['지금 바로 생성하기'] };
+      const answer: Answer = {
+        type: 'checkbox',
+        value: ['지금 바로 생성하기'],
+      };
       const result = validateAnswerForQuestion(question, answer, false);
       expect(result.valid).toBe(true);
     });
@@ -366,7 +369,15 @@ describe('Question Validation Schemas', () => {
         topic_id: '550e8400-e29b-41d4-a716-446655440001',
         question_text: '뉴스레터를 매주 받고 싶은 요일을 선택해주세요',
         question_type: 'delivery_day' as const,
-        options: ['월요일', '화요일', '수요일', '목요일', '금요일', '토요일', '일요일'],
+        options: [
+          '월요일',
+          '화요일',
+          '수요일',
+          '목요일',
+          '금요일',
+          '토요일',
+          '일요일',
+        ],
         display_order: 7,
         is_required: true,
       };

--- a/web/__tests__/lib/validation/question.test.ts
+++ b/web/__tests__/lib/validation/question.test.ts
@@ -252,6 +252,14 @@ describe('Question Validation Schemas', () => {
     it('should return text for custom question', () => {
       expect(getAnswerTypeFromQuestionType('custom')).toBe('text');
     });
+
+    it('should return radio for delivery_day question', () => {
+      expect(getAnswerTypeFromQuestionType('delivery_day')).toBe('radio');
+    });
+
+    it('should return checkbox for generate_now question', () => {
+      expect(getAnswerTypeFromQuestionType('generate_now')).toBe('checkbox');
+    });
   });
 
   describe('validateAnswerForQuestion', () => {
@@ -313,6 +321,73 @@ describe('Question Validation Schemas', () => {
       const result = validateAnswerForQuestion(question, undefined, false);
       expect(result.valid).toBe(false);
       expect(result.error).toBe('필수 질문입니다');
+    });
+
+    it('should validate delivery_day radio answer', () => {
+      const question = createQuestion('delivery_day', true);
+      const answer: Answer = { type: 'radio', value: '월요일' };
+      const result = validateAnswerForQuestion(question, answer, false);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject delivery_day without answer (required)', () => {
+      const question = createQuestion('delivery_day', true);
+      const result = validateAnswerForQuestion(question, undefined, false);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('필수 질문입니다');
+    });
+
+    it('should validate generate_now checkbox answer', () => {
+      const question = createQuestion('generate_now', false);
+      const answer: Answer = { type: 'checkbox', value: ['지금 바로 생성하기'] };
+      const result = validateAnswerForQuestion(question, answer, false);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should validate generate_now when skipped (not required)', () => {
+      const question = createQuestion('generate_now', false);
+      const result = validateAnswerForQuestion(question, undefined, true);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject generate_now with mismatched radio answer type', () => {
+      const question = createQuestion('generate_now', false);
+      const answer: Answer = { type: 'radio', value: '지금 바로 생성하기' };
+      const result = validateAnswerForQuestion(question, answer, false);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('답변 형식이 올바르지 않습니다');
+    });
+  });
+
+  describe('questionSchema with new types', () => {
+    it('should validate delivery_day question type', () => {
+      const question = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        topic_id: '550e8400-e29b-41d4-a716-446655440001',
+        question_text: '뉴스레터를 매주 받고 싶은 요일을 선택해주세요',
+        question_type: 'delivery_day' as const,
+        options: ['월요일', '화요일', '수요일', '목요일', '금요일', '토요일', '일요일'],
+        display_order: 7,
+        is_required: true,
+      };
+
+      const result = questionSchema.safeParse(question);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate generate_now question type', () => {
+      const question = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        topic_id: '550e8400-e29b-41d4-a716-446655440001',
+        question_text: '지금 바로 생성하고 싶으신가요?',
+        question_type: 'generate_now' as const,
+        options: ['지금 바로 생성하기'],
+        display_order: 8,
+        is_required: false,
+      };
+
+      const result = questionSchema.safeParse(question);
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/web/app/api/cron/send-newsletters/route.ts
+++ b/web/app/api/cron/send-newsletters/route.ts
@@ -1,0 +1,97 @@
+import { createAdminClient } from '@/lib/supabase/server';
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = createAdminClient();
+
+  // Calculate tomorrow's day of week (0=Sun, 1=Mon, ..., 6=Sat)
+  const today = new Date();
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const tomorrowDayOfWeek = tomorrow.getDay();
+
+  // Find users whose delivery day is tomorrow with weekly frequency
+  const { data: preferences, error: prefError } = await supabase
+    .from('user_preferences')
+    .select('user_id')
+    .eq('preferred_send_day', tomorrowDayOfWeek)
+    .eq('send_frequency', 'weekly')
+    .eq('email_enabled', true);
+
+  if (prefError) {
+    console.error('Error fetching preferences:', prefError);
+    return Response.json(
+      { error: 'Failed to fetch preferences' },
+      { status: 500 }
+    );
+  }
+
+  if (!preferences || preferences.length === 0) {
+    return Response.json({ message: 'No users scheduled for tomorrow' });
+  }
+
+  const userIds = preferences.map((p) => p.user_id);
+
+  // Find active topics for these users
+  const { data: topics, error: topicsError } = await supabase
+    .from('user_topics')
+    .select('id, user_id')
+    .in('user_id', userIds)
+    .eq('is_active', true);
+
+  if (topicsError) {
+    console.error('Error fetching topics:', topicsError);
+    return Response.json(
+      { error: 'Failed to fetch topics' },
+      { status: 500 }
+    );
+  }
+
+  if (!topics || topics.length === 0) {
+    return Response.json({ message: 'No active topics found' });
+  }
+
+  const apiUrl =
+    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+  // Trigger generation for each user's topic
+  const results = await Promise.allSettled(
+    topics.map(async (topic) => {
+      const response = await fetch(
+        `${apiUrl}/api/newsletter/generate`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            user_id: topic.user_id,
+            topic_id: topic.id,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(
+          `Generation failed for topic ${topic.id}: ${response.status}`
+        );
+      }
+
+      return response.json();
+    })
+  );
+
+  const fulfilled = results.filter((r) => r.status === 'fulfilled').length;
+  const rejected = results.filter((r) => r.status === 'rejected').length;
+
+  return Response.json({
+    message: 'Cron completed',
+    scheduled_day: tomorrowDayOfWeek,
+    users_found: userIds.length,
+    topics_triggered: topics.length,
+    fulfilled,
+    rejected,
+  });
+}

--- a/web/app/api/cron/send-newsletters/route.ts
+++ b/web/app/api/cron/send-newsletters/route.ts
@@ -1,4 +1,5 @@
 import { createAdminClient } from '@/lib/supabase/server';
+import { sendUnsentNewsletter } from '@/lib/email/send-newsletter';
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization');
@@ -8,6 +9,38 @@ export async function GET(request: Request) {
 
   const supabase = createAdminClient();
 
+  // --- Phase 1: Send any published newsletters that haven't been emailed yet ---
+  const { data: unsent } = await supabase
+    .from('newsletters')
+    .select('id')
+    .eq('is_published', true)
+    .is('email_sent_at', null);
+
+  let emailSent = 0;
+  let emailAlreadySent = 0;
+  let emailFailed = 0;
+
+  if (unsent && unsent.length > 0) {
+    const sendResults = await Promise.allSettled(
+      unsent.map((n: { id: string }) => sendUnsentNewsletter(n.id))
+    );
+
+    for (const result of sendResults) {
+      if (result.status === 'fulfilled') {
+        if (result.value.success) {
+          emailSent++;
+        } else if (result.value.alreadySent) {
+          emailAlreadySent++;
+        } else {
+          emailFailed++;
+        }
+      } else {
+        emailFailed++;
+      }
+    }
+  }
+
+  // --- Phase 2: Trigger generation for users scheduled for tomorrow ---
   // Calculate tomorrow's day of week (0=Sun, 1=Mon, ..., 6=Sat)
   const today = new Date();
   const tomorrow = new Date(today);
@@ -31,7 +64,14 @@ export async function GET(request: Request) {
   }
 
   if (!preferences || preferences.length === 0) {
-    return Response.json({ message: 'No users scheduled for tomorrow' });
+    return Response.json({
+      message: 'No users scheduled for tomorrow',
+      emails: {
+        sent: emailSent,
+        alreadySent: emailAlreadySent,
+        failed: emailFailed,
+      },
+    });
   }
 
   const userIds = preferences.map((p) => p.user_id);
@@ -49,7 +89,14 @@ export async function GET(request: Request) {
   }
 
   if (!topics || topics.length === 0) {
-    return Response.json({ message: 'No active topics found' });
+    return Response.json({
+      message: 'No active topics found',
+      emails: {
+        sent: emailSent,
+        alreadySent: emailAlreadySent,
+        failed: emailFailed,
+      },
+    });
   }
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
@@ -81,6 +128,11 @@ export async function GET(request: Request) {
 
   return Response.json({
     message: 'Cron completed',
+    emails: {
+      sent: emailSent,
+      alreadySent: emailAlreadySent,
+      failed: emailFailed,
+    },
     scheduled_day: tomorrowDayOfWeek,
     users_found: userIds.length,
     topics_triggered: topics.length,

--- a/web/app/api/cron/send-newsletters/route.ts
+++ b/web/app/api/cron/send-newsletters/route.ts
@@ -45,33 +45,26 @@ export async function GET(request: Request) {
 
   if (topicsError) {
     console.error('Error fetching topics:', topicsError);
-    return Response.json(
-      { error: 'Failed to fetch topics' },
-      { status: 500 }
-    );
+    return Response.json({ error: 'Failed to fetch topics' }, { status: 500 });
   }
 
   if (!topics || topics.length === 0) {
     return Response.json({ message: 'No active topics found' });
   }
 
-  const apiUrl =
-    process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
   // Trigger generation for each user's topic
   const results = await Promise.allSettled(
     topics.map(async (topic) => {
-      const response = await fetch(
-        `${apiUrl}/api/newsletter/generate`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            user_id: topic.user_id,
-            topic_id: topic.id,
-          }),
-        }
-      );
+      const response = await fetch(`${apiUrl}/api/newsletter/generate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_id: topic.user_id,
+          topic_id: topic.id,
+        }),
+      });
 
       if (!response.ok) {
         throw new Error(

--- a/web/app/api/newsletters/[id]/send/route.ts
+++ b/web/app/api/newsletters/[id]/send/route.ts
@@ -94,7 +94,7 @@ export async function POST(
 
     // Construct newsletter URL
     const siteUrl = env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
-    const newsletterUrl = `${siteUrl}/newsletters/${newsletter.id}`;
+    const newsletterUrl = `${siteUrl}/newsletter/${newsletter.id}`;
 
     // Send email via Resend
     const emailResult = await sendNewsletterEmail({

--- a/web/app/questions/[topicId]/page.tsx
+++ b/web/app/questions/[topicId]/page.tsx
@@ -266,8 +266,29 @@ export default function QuestionsPage() {
                   setGenerationMessage(data.message);
 
                   if (data.step === 'complete' && data.details?.newsletter_id) {
-                    toast.success('뉴스레터가 생성되었습니다! 확인하세요.');
-                    router.push(`/newsletter/${data.details.newsletter_id}`);
+                    const newsletterId = data.details.newsletter_id;
+
+                    // Send email before redirecting
+                    setGenerationMessage('이메일 발송 중...');
+                    try {
+                      const sendRes = await fetch(
+                        `/api/newsletters/${newsletterId}/send`,
+                        { method: 'POST' }
+                      );
+                      if (
+                        sendRes.ok ||
+                        (sendRes.status === 400 &&
+                          (await sendRes.json()).error === 'Already sent')
+                      ) {
+                        toast.success('이메일이 발송되었습니다!');
+                      } else {
+                        toast.error('이메일 발송에 실패했습니다.');
+                      }
+                    } catch {
+                      toast.error('이메일 발송에 실패했습니다.');
+                    }
+
+                    router.push(`/newsletter/${newsletterId}`);
                     return;
                   } else if (data.step === 'error') {
                     toast.error(data.message);

--- a/web/app/questions/[topicId]/page.tsx
+++ b/web/app/questions/[topicId]/page.tsx
@@ -275,16 +275,18 @@ export default function QuestionsPage() {
                         `/api/newsletters/${newsletterId}/send`,
                         { method: 'POST' }
                       );
-                      if (
-                        sendRes.ok ||
-                        (sendRes.status === 400 &&
-                          (await sendRes.json()).error === 'Already sent')
-                      ) {
+                      const sendData = await sendRes.json();
+
+                      if (sendRes.ok || sendData.error === 'Already sent') {
                         toast.success('이메일이 발송되었습니다!');
                       } else {
-                        toast.error('이메일 발송에 실패했습니다.');
+                        console.error('Email send failed:', sendData);
+                        toast.error(
+                          sendData.message || '이메일 발송에 실패했습니다.'
+                        );
                       }
-                    } catch {
+                    } catch (err) {
+                      console.error('Email send error:', err);
                       toast.error('이메일 발송에 실패했습니다.');
                     }
 

--- a/web/app/questions/[topicId]/page.tsx
+++ b/web/app/questions/[topicId]/page.tsx
@@ -9,6 +9,7 @@ import { Progress } from '@/components/ui/progress';
 import { AuthStatus } from '@/components/auth/auth-status';
 import { getQuestionsByTopicId, saveAnswers } from '@/lib/actions/question';
 import { getTopicById } from '@/lib/actions/topic';
+import { saveDeliveryPreference } from '@/lib/actions/preference';
 import { env } from '@/lib/env';
 import { createClient } from '@/lib/supabase/client';
 import type { Question, Answer } from '@/lib/validation/question';
@@ -37,6 +38,8 @@ export default function QuestionsPage() {
   const [generating, setGenerating] = useState(false);
   const [generationProgress, setGenerationProgress] = useState(0);
   const [generationMessage, setGenerationMessage] = useState('');
+  const [scheduled, setScheduled] = useState(false);
+  const [scheduledDay, setScheduledDay] = useState('');
 
   useEffect(() => {
     async function loadData() {
@@ -175,9 +178,41 @@ export default function QuestionsPage() {
           return;
         }
 
-        toast.success('답변이 저장되었습니다! 리서치를 시작합니다.');
+        toast.success('답변이 저장되었습니다!');
 
-        // Get current user
+        // Extract delivery preference answers
+        const deliveryDayState = questionStates.find(
+          (s) => s.question.question_type === 'delivery_day'
+        );
+        const generateNowState = questionStates.find(
+          (s) => s.question.question_type === 'generate_now'
+        );
+
+        const selectedDay =
+          deliveryDayState?.answer?.type === 'radio'
+            ? deliveryDayState.answer.value
+            : null;
+        const shouldGenerateNow =
+          generateNowState?.answer?.type === 'checkbox' &&
+          generateNowState.answer.value.includes('지금 바로 생성하기');
+
+        // Save delivery preference regardless of generate_now
+        if (selectedDay) {
+          const prefResult = await saveDeliveryPreference(selectedDay);
+          if (!prefResult.success) {
+            toast.error(prefResult.message);
+            return;
+          }
+        }
+
+        if (!shouldGenerateNow) {
+          // Scheduled flow: show confirmation screen
+          setScheduledDay(selectedDay || '');
+          setScheduled(true);
+          return;
+        }
+
+        // Immediate generation flow (SSE streaming)
         const supabase = createClient();
         const {
           data: { user },
@@ -188,12 +223,10 @@ export default function QuestionsPage() {
           return;
         }
 
-        // Start newsletter generation with SSE streaming
         setGenerating(true);
         setGenerationProgress(0);
         setGenerationMessage('리서치를 준비하는 중...');
 
-        // Use fetch for SSE streaming
         const apiUrl = env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
         try {
@@ -233,7 +266,6 @@ export default function QuestionsPage() {
                   setGenerationMessage(data.message);
 
                   if (data.step === 'complete' && data.details?.newsletter_id) {
-                    // Generation complete, redirect to newsletter view
                     toast.success('뉴스레터가 생성되었습니다! 확인하세요.');
                     router.push(`/newsletter/${data.details.newsletter_id}`);
                     return;
@@ -264,6 +296,64 @@ export default function QuestionsPage() {
   const totalCount = questionStates.length;
   const progressPercentage =
     totalCount > 0 ? (answeredCount / totalCount) * 100 : 0;
+
+  useEffect(() => {
+    if (!scheduled) return;
+    const timer = setTimeout(() => {
+      router.push('/dashboard');
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [scheduled, router]);
+
+  if (scheduled) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-white dark:bg-black">
+        <Container className="text-center" maxWidth="md">
+          <div className="mb-8">
+            <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900/30">
+              <svg
+                className="h-8 w-8 text-blue-600 dark:text-blue-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <h2 className="mb-3 text-3xl font-bold text-zinc-950 sm:text-4xl dark:text-zinc-50">
+              예약 완료!
+            </h2>
+            <p className="text-lg text-zinc-600 dark:text-zinc-400">
+              매주{' '}
+              <span className="font-semibold text-zinc-950 dark:text-zinc-50">
+                {scheduledDay}
+              </span>
+              마다 뉴스레터를 배송해 드릴게요!
+            </p>
+          </div>
+
+          <p className="mb-8 text-sm text-zinc-500 dark:text-zinc-400">
+            발송 시간은 오전 9시로 고정됩니다.
+            <br />
+            잠시 후 대시보드로 이동합니다...
+          </p>
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.push('/dashboard')}
+          >
+            대시보드로 이동
+          </Button>
+        </Container>
+      </div>
+    );
+  }
 
   if (loading) {
     return (

--- a/web/components/newsletter/newsletter-card.tsx
+++ b/web/components/newsletter/newsletter-card.tsx
@@ -36,6 +36,7 @@ export function NewsletterCard({
 
   const status = newsletter.status;
   const isCompleted = status === 'completed';
+  const isPendingStatus = status === 'pending';
   const isProcessing = status === 'processing';
   const isFailed = status === 'failed';
 
@@ -47,7 +48,7 @@ export function NewsletterCard({
   } as const;
 
   const statusLabels = {
-    pending: '대기 중',
+    pending: '리서치중...',
     processing: '생성 중',
     completed: '완료',
     failed: '실패',
@@ -189,10 +190,12 @@ export function NewsletterCard({
             </>
           )}
 
-          {isProcessing && (
+          {(isPendingStatus || isProcessing) && (
             <div className="flex flex-1 items-center justify-center gap-2 text-blue-600 dark:text-blue-400">
               <div className="h-4 w-4 animate-spin rounded-full border-2 border-blue-600 border-t-transparent"></div>
-              <span className="text-sm">생성 중...</span>
+              <span className="text-sm">
+                {isPendingStatus ? '리서치중...' : '생성 중...'}
+              </span>
             </div>
           )}
 

--- a/web/lib/actions/newsletter.ts
+++ b/web/lib/actions/newsletter.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { env } from '@/lib/env';
+import { sendUnsentNewsletter } from '@/lib/email/send-newsletter';
 
 interface GenerateNewsletterResult {
   success: boolean;
@@ -420,6 +421,10 @@ interface SendNewsletterEmailResult {
 /**
  * Send newsletter email to user.
  *
+ * Uses the admin client via sendUnsentNewsletter so this works correctly
+ * from any server context (server actions, cron, etc.) without needing
+ * the user's auth cookies.
+ *
  * @param newsletterId - Newsletter UUID
  * @returns Result with success status and email ID
  */
@@ -427,34 +432,29 @@ export async function sendNewsletterEmail(
   newsletterId: string
 ): Promise<SendNewsletterEmailResult> {
   try {
-    // Get site URL for API endpoint
-    const siteUrl = env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+    const result = await sendUnsentNewsletter(newsletterId);
 
-    // Call API endpoint to send email
-    const response = await fetch(
-      `${siteUrl}/api/newsletters/${newsletterId}/send`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
-    );
+    if (result.alreadySent) {
+      return {
+        success: true,
+        message: '이미 발송된 뉴스레터입니다.',
+        emailId: undefined,
+        sentAt: undefined,
+      };
+    }
 
-    const data = await response.json();
-
-    if (!response.ok) {
+    if (!result.success) {
       return {
         success: false,
-        message: data.message || '이메일 발송에 실패했습니다.',
+        message: result.error || '이메일 발송에 실패했습니다.',
       };
     }
 
     return {
       success: true,
-      message: data.message || '이메일이 성공적으로 발송되었습니다.',
-      emailId: data.emailId,
-      sentAt: data.sentAt,
+      message: '이메일이 성공적으로 발송되었습니다.',
+      emailId: result.emailId,
+      sentAt: new Date().toISOString(),
     };
   } catch (error) {
     console.error('Error sending newsletter email:', error);

--- a/web/lib/actions/newsletter.ts
+++ b/web/lib/actions/newsletter.ts
@@ -218,7 +218,7 @@ export async function getUserNewsletters(
       { count: 'exact' }
     )
     .eq('user_id', user.id)
-    .in('status', ['completed', 'processing']); // Only show completed and processing
+    .in('status', ['pending', 'processing', 'completed']); // Include pending for scheduled newsletters
 
   // Apply filters
   if (topicId) {

--- a/web/lib/actions/preference.ts
+++ b/web/lib/actions/preference.ts
@@ -1,0 +1,68 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+const DAY_NAME_TO_INT: Record<string, number> = {
+  '월요일': 1,
+  '화요일': 2,
+  '수요일': 3,
+  '목요일': 4,
+  '금요일': 5,
+  '토요일': 6,
+  '일요일': 0,
+};
+
+export async function saveDeliveryPreference(deliveryDay: string) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { success: false, message: '로그인이 필요합니다.' };
+  }
+
+  const dayInt = DAY_NAME_TO_INT[deliveryDay];
+  if (dayInt === undefined) {
+    return { success: false, message: '올바르지 않은 요일입니다.' };
+  }
+
+  // Check if preference row already exists
+  const { data: existing } = await supabase
+    .from('user_preferences')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (existing) {
+    const { error } = await supabase
+      .from('user_preferences')
+      .update({
+        send_frequency: 'weekly',
+        preferred_send_day: dayInt,
+        preferred_send_time: '09:00:00',
+      })
+      .eq('user_id', user.id);
+
+    if (error) {
+      console.error('Error updating delivery preference:', error);
+      return { success: false, message: '발송 주기 저장에 실패했습니다.' };
+    }
+  } else {
+    const { error } = await supabase.from('user_preferences').insert({
+      user_id: user.id,
+      send_frequency: 'weekly',
+      preferred_send_day: dayInt,
+      preferred_send_time: '09:00:00',
+    });
+
+    if (error) {
+      console.error('Error inserting delivery preference:', error);
+      return { success: false, message: '발송 주기 저장에 실패했습니다.' };
+    }
+  }
+
+  return { success: true, message: '발송 주기가 저장되었습니다.' };
+}

--- a/web/lib/actions/preference.ts
+++ b/web/lib/actions/preference.ts
@@ -3,13 +3,13 @@
 import { createClient } from '@/lib/supabase/server';
 
 const DAY_NAME_TO_INT: Record<string, number> = {
-  '월요일': 1,
-  '화요일': 2,
-  '수요일': 3,
-  '목요일': 4,
-  '금요일': 5,
-  '토요일': 6,
-  '일요일': 0,
+  월요일: 1,
+  화요일: 2,
+  수요일: 3,
+  목요일: 4,
+  금요일: 5,
+  토요일: 6,
+  일요일: 0,
 };
 
 export async function saveDeliveryPreference(deliveryDay: string) {

--- a/web/lib/default-questions.ts
+++ b/web/lib/default-questions.ts
@@ -68,7 +68,15 @@ export const defaultQuestions: DefaultQuestion[] = [
   {
     question_text: '뉴스레터를 매주 받고 싶은 요일을 선택해주세요',
     question_type: 'delivery_day',
-    options: ['월요일', '화요일', '수요일', '목요일', '금요일', '토요일', '일요일'],
+    options: [
+      '월요일',
+      '화요일',
+      '수요일',
+      '목요일',
+      '금요일',
+      '토요일',
+      '일요일',
+    ],
     display_order: 7,
     is_required: true,
   },

--- a/web/lib/default-questions.ts
+++ b/web/lib/default-questions.ts
@@ -9,7 +9,9 @@ export interface DefaultQuestion {
     | 'scope'
     | 'time'
     | 'source'
-    | 'subtopic';
+    | 'subtopic'
+    | 'delivery_day'
+    | 'generate_now';
   options: string[];
   display_order: number;
   is_required: boolean;
@@ -61,6 +63,20 @@ export const defaultQuestions: DefaultQuestion[] = [
     question_type: 'subtopic',
     options: [],
     display_order: 6,
+    is_required: false,
+  },
+  {
+    question_text: '뉴스레터를 매주 받고 싶은 요일을 선택해주세요',
+    question_type: 'delivery_day',
+    options: ['월요일', '화요일', '수요일', '목요일', '금요일', '토요일', '일요일'],
+    display_order: 7,
+    is_required: true,
+  },
+  {
+    question_text: '지금 바로 생성하고 싶으신가요?',
+    question_type: 'generate_now',
+    options: ['지금 바로 생성하기'],
+    display_order: 8,
     is_required: false,
   },
 ];

--- a/web/lib/email/send-newsletter.ts
+++ b/web/lib/email/send-newsletter.ts
@@ -1,0 +1,111 @@
+import { createAdminClient } from '@/lib/supabase/server';
+import { sendNewsletterEmail } from '@/lib/email/resend';
+import { env } from '@/lib/env';
+
+export interface SendUnsentNewsletterResult {
+  success: boolean;
+  emailId?: string;
+  error?: string;
+  alreadySent?: boolean;
+}
+
+/**
+ * Server-side utility to send a newsletter email using the admin client.
+ * Safe to call from cron jobs or any server context without cookie dependency.
+ */
+export async function sendUnsentNewsletter(
+  newsletterId: string
+): Promise<SendUnsentNewsletterResult> {
+  const supabase = createAdminClient();
+
+  // Fetch newsletter with topic
+  const { data: newsletter, error: fetchError } = await supabase
+    .from('newsletters')
+    .select(
+      `
+      id,
+      user_id,
+      topic_id,
+      email_sent_at,
+      user_topics!inner(topic_text, created_at)
+    `
+    )
+    .eq('id', newsletterId)
+    .single<{
+      id: string;
+      user_id: string;
+      topic_id: string;
+      email_sent_at: string | null;
+      user_topics: {
+        topic_text: string;
+        created_at: string;
+      };
+    }>();
+
+  if (fetchError || !newsletter) {
+    return { success: false, error: 'Newsletter not found' };
+  }
+
+  // Already sent — idempotent short-circuit
+  if (newsletter.email_sent_at) {
+    return { success: false, alreadySent: true };
+  }
+
+  // Check 4-week limit
+  const topicCreatedAt = new Date(newsletter.user_topics.created_at);
+  const fourWeeksInMs = 4 * 7 * 24 * 60 * 60 * 1000;
+  if (Date.now() - topicCreatedAt.getTime() > fourWeeksInMs) {
+    return { success: false, error: 'Topic exceeded 4-week limit' };
+  }
+
+  // Look up user email via admin API
+  const { data: userData, error: userError } =
+    await supabase.auth.admin.getUserById(newsletter.user_id);
+
+  if (userError || !userData?.user?.email) {
+    return { success: false, error: 'Failed to fetch user email' };
+  }
+
+  const siteUrl = env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const newsletterUrl = `${siteUrl}/newsletter/${newsletter.id}`;
+
+  // Send via Resend
+  const emailResult = await sendNewsletterEmail({
+    userEmail: userData.user.email,
+    topic: newsletter.user_topics.topic_text,
+    newsletterId: newsletter.id,
+    newsletterUrl,
+  });
+
+  if (!emailResult.success) {
+    await supabase.from('email_events').insert({
+      newsletter_id: newsletter.id,
+      user_id: newsletter.user_id,
+      event_type: 'failed',
+      email_provider: 'resend',
+      metadata: { error: emailResult.error },
+    });
+    return { success: false, error: emailResult.error };
+  }
+
+  // Persist sent timestamp
+  await supabase
+    .from('newsletters')
+    .update({ email_sent_at: new Date().toISOString() })
+    .eq('id', newsletter.id);
+
+  // Log success event
+  await supabase.from('email_events').insert({
+    newsletter_id: newsletter.id,
+    user_id: newsletter.user_id,
+    event_type: 'sent',
+    email_provider: 'resend',
+    email_provider_id: emailResult.id,
+    metadata: {
+      recipient: userData.user.email,
+      topic: newsletter.user_topics.topic_text,
+    },
+  });
+
+  return { success: true, emailId: emailResult.id };
+}

--- a/web/lib/validation/question.ts
+++ b/web/lib/validation/question.ts
@@ -9,6 +9,8 @@ export const questionTypeEnum = z.enum([
   'source',
   'subtopic',
   'custom',
+  'delivery_day',
+  'generate_now',
 ]);
 
 // Base question schema
@@ -92,9 +94,11 @@ export function getAnswerTypeFromQuestionType(
     case 'goal':
     case 'difficulty':
     case 'time':
+    case 'delivery_day':
       return 'radio';
     case 'source':
     case 'scope':
+    case 'generate_now':
       return 'checkbox';
     case 'subtopic':
     case 'custom':

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -107,6 +107,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1784,6 +1785,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.2.1.tgz",
       "integrity": "sha512-ljDiQiJDu/Fq//vSIIP0z5Nuvt4+DX1RqGasstChDGJB/14ogd4VdNS9aacoede/ZjGy3o3Qb+cxyS+XgM6SwQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1796,6 +1798,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.2.1.tgz",
       "integrity": "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1808,6 +1811,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.2.1.tgz",
       "integrity": "sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prismjs": "^1.30.0"
       },
@@ -1823,6 +1827,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.6.tgz",
       "integrity": "sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1881,6 +1886,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.16.tgz",
       "integrity": "sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1917,6 +1923,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.16.tgz",
       "integrity": "sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1929,6 +1936,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.12.tgz",
       "integrity": "sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1953,6 +1961,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.12.tgz",
       "integrity": "sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1965,6 +1974,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.13.tgz",
       "integrity": "sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1992,6 +2002,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.14.tgz",
       "integrity": "sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -2103,6 +2114,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.6.tgz",
       "integrity": "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -2599,6 +2611,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.91.0.tgz",
       "integrity": "sha512-Rjb0QqkKrmXMVwUOdEqysPBZ0ZDZakeptTkUa6k2d8r3strBdbWVDqjOdkCjAmvvZMtXecBeyTyMEXD1Zzjfvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.91.0",
         "@supabase/functions-js": "2.91.0",
@@ -2977,7 +2990,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3074,8 +3086,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3205,6 +3216,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3215,6 +3227,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3332,6 +3345,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -3965,6 +3979,7 @@
       "integrity": "sha512-hRDjg6dlDz7JlZAvjbiCdAJ3SDG+NH8tjZe21vjxfvT2ssYAn72SRXMge3dKKABm3bIJ3C+3wdunIdur8PHEAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.17",
         "fflate": "^0.8.2",
@@ -4042,6 +4057,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4503,6 +4519,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4960,7 +4977,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5182,8 +5200,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -5664,6 +5681,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5865,6 +5883,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6630,6 +6649,7 @@
       "integrity": "sha512-rfbiwB6OKxZFIFQ7SRnCPB2WL9WhyXsFoTfecYgeCeFSOBxvkWLaXsdv5ehzJrfqwXQmDephAKWLRQoFoJwrew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -8104,7 +8124,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9850,6 +9869,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
       "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9945,7 +9965,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9961,7 +9980,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9974,8 +9992,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -10067,6 +10084,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10599,6 +10617,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11976,6 +11995,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12087,6 +12107,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -12213,6 +12234,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12511,6 +12533,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12604,6 +12627,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12617,6 +12641,7 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",
@@ -12986,6 +13011,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

- Add **delivery day selection** (radio, required) and a **"지금 바로 생성하기" checkbox** (optional) as the last two personalization questions shown after topic creation.
- When the checkbox is **unchecked** (default), the user's weekly delivery preference is persisted to `user_preferences` and a confirmation screen is shown ("매주 [요일]마다 뉴스레터를 배송해 드릴게요!") before redirecting to the dashboard.
- When the checkbox is **checked**, the existing SSE-based immediate newsletter generation flow runs unchanged.
- A **Vercel Cron job** (`0 0 * * *` / 09:00 KST) queries users whose delivery day falls on the next day and triggers generation via the FastAPI backend for each of their active topics.
- Dashboard newsletter cards now display a **"리서치중…"** badge and spinner for requests in `pending` status.

## Changes

| Area | Details |
|---|---|
| DB | New migration (`20260203`) extends the `question_type` constraint with `delivery_day` and `generate_now` |
| Questions | `default-questions.ts` — two new questions (delivery_day radio, generate_now checkbox); `validation/question.ts` — type enum and answer-type mapping extended |
| Server action | `lib/actions/preference.ts` — `saveDeliveryPreference` upserts `user_preferences` with the chosen day and `weekly` frequency |
| Questions page | Conditional post-submit flow: extract answers, branch on `generate_now`, show scheduled-confirmation screen with 3-second auto-redirect |
| Cron | `app/api/cron/send-newsletters/route.ts` — CRON_SECRET-authenticated GET handler; `vercel.json` updated with cron entry |
| Dashboard | `newsletter.ts` action includes `pending` status; card renders "리서치중…" + spinner for pending items |

## Test plan

- [ ] Select a delivery day, **leave checkbox unchecked** → confirmation screen appears with the chosen day, auto-redirects to `/dashboard` after 3 s
- [ ] Select a delivery day, **check the checkbox** → existing "리서시 중…" SSE progress screen, newsletter generated immediately
- [ ] Visit `/dashboard` while a newsletter request is in `pending` status → card shows "리서치중…" badge with spinner
- [ ] Hit the cron endpoint with an invalid / missing `Authorization` header → 401
- [ ] Run the full test suite → 324 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)