### PR TITLE
feat: surface PyTorch-KR primary sources in research

### DIFF
--- a/docs/plans/2026-07-15-pytorch-kr-forum-research.md
+++ b/docs/plans/2026-07-15-pytorch-kr-forum-research.md
@@ -1,0 +1,546 @@
+# PyTorch-KR Forum Research Source Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add recent PyTorch-KR 읽을거리&정보공유 posts to the deterministic weekly-research pipeline, preserving two Korean summary paragraphs and the post's primary external source URL.
+
+**Architecture:** A source adapter in `src/tools/search_tools.py` uses the public Discourse JSON API to paginate category topics and retrieve each in-range topic's original post. It produces normalized source records containing forum metadata, a cleaned two-paragraph excerpt, and an external primary URL. `src/tools/research_collector.py` then routes the new source through its existing normalization, deduplication, ranking, bounded enrichment, artifact persistence, and research-agent reporting flow.
+
+**Tech Stack:** Python 3.11+, `httpx`, Beautiful Soup 4, `pytest`, `unittest.mock`, existing `uv` project tooling.
+
+**Branch:** `feature/pytorch-kr-forum-research`
+
+**Design spec:** `docs/superpowers/specs/2026-07-15-pytorch-kr-forum-research-design.md`
+
+**Known baseline:** `uv run pytest -m 'not integration'` currently reports **64 passed, 1 skipped, 8 errors**. The errors are pre-existing and unrelated: `tests/test_email_flow.py` patches nonexistent `src.api.newsletter_generator`. The target test suites (`tests/test_blog_scraping.py` and `tests/test_research_collector.py`) pass. Do not repair the email-flow suite in this feature.
+
+---
+
+## Task 1: Add deterministic parser and pagination tests for the forum adapter
+
+**Objective:** Define the exact API, date-window, paragraph, URL-selection, and error-isolation behavior before implementing network code.
+
+**Files:**
+- Create: `tests/test_pytorch_kr_forum.py`
+- Modify: `src/tools/search_tools.py` (implementation follows in Task 2)
+
+**Step 1: Add reusable test fixtures**
+
+Create small inline JSON/HTML fixtures in `tests/test_pytorch_kr_forum.py` rather than recording live responses:
+
+- A listing page with an in-window topic, an exactly-seven-days-old topic, an older topic, and a pinned topic.
+- A second page used to prove pagination and early stopping.
+- Topic JSON whose `post_stream.posts[0].cooked` begins with an image-only paragraph, has two substantive Korean `<p>` elements, includes an external `data-onebox-src`, and ends with standard forum/footer links.
+- A topic JSON with no onebox but an external plain hyperlink.
+- A topic JSON with no qualifying external URL.
+
+Use one `publication_date` (`"2026-07-15"`) throughout so the expected inclusive range is `2026-07-08` through `2026-07-15`.
+
+**Step 2: Write failing pure-parser tests**
+
+Import the planned helpers from `src.tools.search_tools`:
+
+```python
+from src.tools.search_tools import (
+    _extract_pytorch_kr_post_fields,
+    _fetch_pytorch_kr_forum_posts,
+    search_pytorch_kr_forum,
+)
+
+
+def test_extracts_two_meaningful_paragraphs_and_onebox_source():
+    content, original_url = _extract_pytorch_kr_post_fields(
+        SAMPLE_TOPIC_HTML,
+        "https://discuss.pytorch.kr/t/example/101",
+    )
+
+    assert content == "첫 번째 실제 본문입니다.\n\n두 번째 실제 본문입니다."
+    assert original_url == "https://github.com/example/project"
+
+
+def test_plain_external_link_is_used_when_no_onebox_exists():
+    _, original_url = _extract_pytorch_kr_post_fields(
+        SAMPLE_PLAIN_LINK_HTML,
+        "https://discuss.pytorch.kr/t/example/102",
+    )
+    assert original_url == "https://arxiv.org/abs/2601.00001"
+
+
+def test_forum_url_is_used_when_no_primary_source_exists():
+    forum_url = "https://discuss.pytorch.kr/t/example/103"
+    _, original_url = _extract_pytorch_kr_post_fields(SAMPLE_NO_SOURCE_HTML, forum_url)
+    assert original_url == forum_url
+```
+
+Also write tests proving PyTorchKR-internal URLs, `/uploads/` media URLs, anchors, signup/home, Telegram, and footer/notification links are not chosen as primary sources.
+
+**Step 3: Run parser tests to verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/test_pytorch_kr_forum.py -q
+```
+
+Expected: collection/import failure because the adapter helpers do not exist yet.
+
+**Step 4: Write failing pagination and error-isolation tests**
+
+Use a fake `httpx.Client` (or a `MockTransport`) with deterministic URL responses. Call `_fetch_pytorch_kr_forum_posts` with `request_delay_seconds=0` and assert:
+
+- only non-pinned topics dated `2026-07-08` through `2026-07-15` are returned;
+- an old topic is not fetched for detail;
+- the second page is reached when needed;
+- pagination stops once a non-pinned page is entirely older than the lower boundary;
+- a failed `/t/{id}.json` detail call is recorded in errors while other posts are returned;
+- returned source records include `title`, `forum_url`, `original_url`, `content`, `published_at`, and `tags`;
+- the public `search_pytorch_kr_forum` serializes the envelope as JSON rather than raising on source failure.
+
+**Step 5: Commit the red tests**
+
+```bash
+git add tests/test_pytorch_kr_forum.py
+git commit -m "test: define PyTorch-KR forum source behavior"
+```
+
+---
+
+## Task 2: Implement the bounded, courteous Discourse source adapter
+
+**Objective:** Make the tests from Task 1 pass without browser automation or additional dependencies.
+
+**Files:**
+- Modify: `src/tools/search_tools.py:1-123`
+- Test: `tests/test_pytorch_kr_forum.py`
+
+**Step 1: Add constants and imports**
+
+Add only the imports needed by the adapter:
+
+```python
+import time
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+```
+
+Define configuration close to the imports:
+
+```python
+PYTORCH_KR_BASE_URL = "https://discuss.pytorch.kr"
+PYTORCH_KR_NEWS_CATEGORY_ID = 14
+PYTORCH_KR_MAX_PAGES = 5
+PYTORCH_KR_REQUEST_DELAY_SECONDS = 0.2
+PYTORCH_KR_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+}
+```
+
+Do not add Playwright, Selenium, or a browser dependency.
+
+**Step 2: Implement pure content and URL helpers**
+
+Add helpers with narrow responsibilities:
+
+```python
+def _parse_pytorch_kr_created_at(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def _is_pytorch_kr_primary_source(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return False
+    host = parsed.netloc.lower()
+    if host == "discuss.pytorch.kr" or host.endswith(".discuss.pytorch.kr"):
+        return False
+    return host not in {"pytorch.kr", "t.me", "discuss-noti.pytorch.kr"}
+```
+
+Make the final implementation additionally reject image/media URLs by path/extension and rely on the DOM position to avoid footer links. `_extract_pytorch_kr_post_fields(cooked, forum_url)` must:
+
+1. parse `cooked` with Beautiful Soup;
+2. collect the first two non-empty `<p>` texts after HTML stripping, ignoring image-only nodes and known community/footer boilerplate;
+3. choose the first qualifying external `data-onebox-src` in document order;
+4. otherwise choose the first qualifying external `<a href>` in document order;
+5. fall back to `forum_url`.
+
+Return `(content, original_url)`, with paragraph text joined by `"\n\n"`.
+
+**Step 3: Implement pagination/detail collection**
+
+Add an internal, dependency-injected helper:
+
+```python
+def _fetch_pytorch_kr_forum_posts(
+    client: httpx.Client,
+    publication_date: str,
+    *,
+    max_pages: int = PYTORCH_KR_MAX_PAGES,
+    request_delay_seconds: float = PYTORCH_KR_REQUEST_DELAY_SECONDS,
+) -> tuple[list[dict], list[str]]:
+    """Return source records and recoverable errors for the requested week."""
+```
+
+Implementation requirements:
+
+- Parse `publication_date` using `%Y-%m-%d`; set `start = publication_date - timedelta(days=7)` and `end` to `23:59:59` on the publication day.
+- Fetch `/c/news/14/l/latest.json?page={page}` in page order, using the constants above.
+- Ignore pinned topics and duplicate topic ids.
+- Build a forum permalink as `f"{PYTORCH_KR_BASE_URL}/t/{slug}/{id}"`.
+- Only call `/t/{id}.json` for a topic whose parseable `created_at` is inside the inclusive range.
+- Stop on an empty listing, no `more_topics_url`, the configured maximum, or after processing a page whose non-pinned, parseable topics are all older than `start`.
+- Fetch topic details sequentially. Delay only between detail requests and only if another eligible topic remains.
+- For every successful detail request, create exactly this source record:
+
+```python
+{
+    "title": topic["title"],
+    "forum_url": forum_url,
+    "original_url": original_url,
+    "content": content,
+    "published_at": created_at.strftime("%Y-%m-%d"),
+    "tags": [tag["slug"] if isinstance(tag, dict) else tag for tag in topic.get("tags", [])],
+}
+```
+
+- Treat listing failures as a source error and return no further data; treat individual detail failures as per-topic errors and continue.
+
+**Step 4: Add the public tool function**
+
+Implement the public wrapper, preserving the existing tools' error-as-data behavior:
+
+```python
+def search_pytorch_kr_forum(publication_date: str) -> str:
+    """Collect seven days of PyTorchKR 읽을거리&정보공유 forum topics.
+
+    Returns a JSON envelope with publication_date, date_range, posts, and
+    optional errors. Each post preserves two forum paragraphs and its primary
+    external source URL.
+    """
+```
+
+Use `httpx.Client(timeout=30.0, follow_redirects=True)`, call the internal helper, and serialize with `ensure_ascii=False, indent=2`. Invalid dates and top-level HTTP/JSON failures must return a valid JSON envelope containing an `errors` list.
+
+**Step 5: Run focused tests to verify pass**
+
+Run:
+
+```bash
+uv run pytest tests/test_pytorch_kr_forum.py -q
+```
+
+Expected: all new adapter tests pass.
+
+**Step 6: Run the live source check (optional integration test)**
+
+After adding the integration test in Task 4, run:
+
+```bash
+uv run pytest tests/test_pytorch_kr_forum.py -m integration -q
+```
+
+Expected: the live forum test passes for the current date window, or produces a clear external-network failure without affecting ordinary test runs.
+
+**Step 7: Commit adapter implementation**
+
+```bash
+git add src/tools/search_tools.py tests/test_pytorch_kr_forum.py
+git commit -m "feat: collect recent PyTorch-KR forum posts"
+```
+
+---
+
+## Task 3: Route forum records through the deterministic collector
+
+**Objective:** Integrate the source with existing candidate normalization and bounded enrichment without giving it a quota or refetching its forum pages.
+
+**Files:**
+- Modify: `src/tools/research_collector.py:15-18, 35-48, 69-112, 123-188, 261-286`
+- Modify: `tests/test_research_collector.py:5-37, 66-168, 250-293, 381-458`
+
+**Step 1: Write failing collector tests**
+
+First update the test import list and `EXPECTED_CATEGORIES` to include `"pytorch_kr_community"`. Add a fake forum adapter envelope:
+
+```python
+def fake_search_pytorch_kr_forum(publication_date):
+    return json.dumps({
+        "publication_date": publication_date,
+        "date_range": {"start": "2026-06-10", "end": "2026-06-17"},
+        "posts": [{
+            "title": "Forum Item",
+            "forum_url": "https://discuss.pytorch.kr/t/forum-item/1",
+            "original_url": "https://github.com/example/project",
+            "content": "첫 문단\n\n둘째 문단",
+            "published_at": "2026-06-12",
+            "tags": ["llm", "agent"],
+        }],
+    })
+```
+
+Use it in all `_run_searches` and `_collect_weekly_research_core` tests so the expanded plan never calls the live forum.
+
+Add assertions that the `pytorch_kr` raw result is labeled `pytorch_kr_community` and that normalization creates:
+
+```python
+{
+    "url": "https://discuss.pytorch.kr/t/forum-item/1",
+    "original_url": "https://github.com/example/project",
+    "source": "discuss.pytorch.kr",
+    "published_at": "2026-06-12",
+    "summary": "첫 문단\n\n둘째 문단",
+    "prefetched_content": "첫 문단\n\n둘째 문단",
+    "category": "pytorch_kr_community",
+    "topic_type": "main",
+    "fetched": False,
+    "score": 0.0,
+}
+```
+
+Write a failing `_fetch_top_candidates` test proving a prefetched forum candidate:
+
+- consumes one slot in the existing `max_fetches` slice,
+- adds `prefetched_content[:max_chars_per_source]` under the candidate's forum `url`,
+- sets `fetched=True`, and
+- never calls `fetch_article_content` for that candidate.
+
+**Step 2: Run collector tests to verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/test_research_collector.py -q
+```
+
+Expected: failures for the missing category/tool branch and prefetched-content behavior.
+
+**Step 3: Add query-plan and search dispatch support**
+
+Import `search_pytorch_kr_forum` alongside the existing search functions. Add this entry to `RESEARCH_QUERY_PLAN`:
+
+```python
+{"category": "pytorch_kr_community", "tool": "pytorch_kr", "query": None},
+```
+
+In `_run_searches`, add a `pytorch_kr` branch that parses the public adapter's envelope, appends source errors with a `pytorch_kr_community/pytorch_kr:` prefix, and assigns `items = result.get("posts", [])`. Keep failures isolated, exactly like the existing blog source handling.
+
+**Step 4: Add candidate normalization support**
+
+In `_normalize_candidates`, add a `pytorch_kr` branch before the final missing-title/URL guard:
+
+```python
+elif tool == "pytorch_kr":
+    url = item.get("forum_url", "")
+    title = item.get("title", "")
+    published_at = item.get("published_at")
+    score = 0.0
+    summary = item.get("content", "")
+    source = "discuss.pytorch.kr"
+    original_url = item.get("original_url", url)
+    prefetched_content = summary
+```
+
+Extend the candidate construction only for this branch to include `original_url` and `prefetched_content`. Do not alter the fields or scores of Tavily, HN, and official-blog candidates.
+
+**Step 5: Reuse prefetched excerpts inside the shared enrichment budget**
+
+Adjust `_fetch_top_candidates` so its existing `candidates[:max_fetches]` loop checks `candidate.get("prefetched_content")` before calling `fetch_article_content`:
+
+```python
+prefetched_content = candidate.get("prefetched_content")
+if prefetched_content:
+    fetched_content[candidate["url"]] = prefetched_content[:max_chars_per_source]
+    candidate["fetched"] = True
+    continue
+```
+
+This preserves the existing shared `max_fetches` cap. Do not pre-enrich every scraped forum post and do not make extra generic fetches of selected forum pages.
+
+**Step 6: Run the collector suite to verify pass**
+
+Run:
+
+```bash
+uv run pytest tests/test_research_collector.py -q
+```
+
+Expected: all collector tests pass, including the new forum category and prefetched-content test.
+
+**Step 7: Commit collector integration**
+
+```bash
+git add src/tools/research_collector.py tests/test_research_collector.py
+git commit -m "feat: integrate PyTorch-KR candidates into research"
+```
+
+---
+
+## Task 4: Expose the primary source to the research agent and add a live regression check
+
+**Objective:** Ensure the research report makes both the forum context and original-source citation available to downstream article writing.
+
+**Files:**
+- Modify: `src/config.py:69-102`
+- Modify: `tests/test_prompts.py`
+- Modify: `tests/test_pytorch_kr_forum.py`
+
+**Step 1: Write a failing prompt-contract test**
+
+Add a focused test in `tests/test_prompts.py` that asserts `RESEARCH_AGENT_PROMPT` instructs the agent to:
+
+- recognize optional `original_url` on candidates;
+- list the forum URL as the community source;
+- list the primary/original URL separately whenever it differs from the forum URL.
+
+Keep the test textual and narrow; do not construct an LLM or call external APIs.
+
+**Step 2: Run the prompt test to verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/test_prompts.py -q
+```
+
+Expected: the new assertion fails because the existing prompt only documents `url`.
+
+**Step 3: Update the report contract in `RESEARCH_AGENT_PROMPT`**
+
+Revise the candidate-field text and final-report format so the report contains, for each PyTorchKR candidate:
+
+```text
+3. 포럼 출처 URL: <forum_url>
+4. 원문/주요 출처 URL: <original_url>   # only when different
+5. 발표/게시 날짜: <published_at>
+```
+
+Renumber the subsequent fields consistently. State that article writers should use `original_url` for fact verification when present, while retaining the forum URL as the Korean-community context. Do not modify unrelated orchestrator, topic-selector, or article-writer style requirements.
+
+**Step 4: Add a marked live integration test**
+
+Add an `@pytest.mark.integration` test in `tests/test_pytorch_kr_forum.py` that uses the current date window:
+
+```python
+from datetime import datetime, timedelta
+
+
+@pytest.mark.integration
+def test_live_pytorch_kr_forum_returns_structured_posts():
+    publication_date = datetime.now().strftime("%Y-%m-%d")
+    earliest_date = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
+
+    payload = json.loads(search_pytorch_kr_forum(publication_date))
+    assert payload["publication_date"] == publication_date
+    assert payload["posts"]
+    post = payload["posts"][0]
+    assert post["title"]
+    assert post["forum_url"].startswith("https://discuss.pytorch.kr/t/")
+    assert earliest_date <= post["published_at"] <= publication_date
+    assert post["content"]
+    assert post["original_url"].startswith("http")
+```
+
+The current date is deliberate: the source adapter itself is date-relative, and the marked live test should continue to exercise the currently available category pages. It remains excluded from the default suite.
+
+**Step 5: Run target verification**
+
+Run:
+
+```bash
+uv run pytest tests/test_pytorch_kr_forum.py tests/test_research_collector.py tests/test_prompts.py -q
+uv run pytest -m integration tests/test_pytorch_kr_forum.py -q
+```
+
+Expected: all offline target tests pass; the marked live test passes when the forum is reachable.
+
+**Step 6: Record the known full-suite baseline separately**
+
+Run:
+
+```bash
+uv run pytest -m 'not integration'
+```
+
+Expected: feature-target tests remain green; the known `tests/test_email_flow.py` errors may persist unchanged. Report these separately and do not claim full-suite green unless that unrelated baseline is corrected in another scope.
+
+**Step 7: Commit prompt/report integration**
+
+```bash
+git add src/config.py tests/test_prompts.py tests/test_pytorch_kr_forum.py
+git commit -m "feat: surface PyTorch-KR primary sources in research"
+```
+
+---
+
+## Task 5: Final feature verification and Kanban handoff
+
+**Objective:** Verify the branch contains the design, plan, and implementation with only intended changes, then make the existing Kanban card executable.
+
+**Files:**
+- Verify: `docs/superpowers/specs/2026-07-15-pytorch-kr-forum-research-design.md`
+- Verify: `docs/plans/2026-07-15-pytorch-kr-forum-research.md`
+- Verify: `src/tools/search_tools.py`
+- Verify: `src/tools/research_collector.py`
+- Verify: `src/config.py`
+- Verify: `tests/test_pytorch_kr_forum.py`
+- Verify: `tests/test_research_collector.py`
+- Verify: `tests/test_prompts.py`
+
+**Step 1: Inspect the feature diff**
+
+Run:
+
+```bash
+git diff --check origin/dev...HEAD
+git diff --stat origin/dev...HEAD
+git status --short
+```
+
+Expected: no whitespace errors and only the planned implementation, test, design, and plan files changed.
+
+**Step 2: Run the final target suites**
+
+Run:
+
+```bash
+uv run pytest tests/test_pytorch_kr_forum.py tests/test_research_collector.py tests/test_prompts.py -q
+```
+
+Expected: all selected tests pass.
+
+**Step 3: Run the live source check**
+
+Run:
+
+```bash
+uv run pytest -m integration tests/test_pytorch_kr_forum.py -q
+```
+
+Expected: the public endpoint works and returns structured data. If external availability blocks it, capture the exact error but do not treat it as an offline-unit-test regression.
+
+**Step 4: Unblock and update the Kanban card only after plan approval**
+
+Run:
+
+```bash
+hermes kanban --board newsletter-automation-gpters unblock t_ac24560b
+hermes kanban --board newsletter-automation-gpters comment t_ac24560b \
+  'Implementation plan approved and committed on feature/pytorch-kr-forum-research; execution may begin.'
+```
+
+Expected: `t_ac24560b` becomes ready with the implementation-plan status recorded.
+
+**Step 5: Commit the implementation plan (this planning phase)**
+
+```bash
+git add docs/plans/2026-07-15-pytorch-kr-forum-research.md
+git commit -m "docs: add PyTorch-KR forum implementation plan"
+```

--- a/docs/plans/2026-07-15-pytorch-kr-forum-research.md
+++ b/docs/plans/2026-07-15-pytorch-kr-forum-research.md
@@ -499,8 +499,8 @@ git commit -m "feat: surface PyTorch-KR primary sources in research"
 Run:
 
 ```bash
-git diff --check origin/dev...HEAD
-git diff --stat origin/dev...HEAD
+git diff --check personal...HEAD
+git diff --stat personal...HEAD
 git status --short
 ```
 

--- a/docs/superpowers/specs/2026-07-15-pytorch-kr-forum-research-design.md
+++ b/docs/superpowers/specs/2026-07-15-pytorch-kr-forum-research-design.md
@@ -1,0 +1,152 @@
+# PyTorch-KR Forum Research Source — Design
+
+**Date:** 2026-07-15  
+**Status:** Approved for specification; awaiting user review before implementation
+
+## Goal
+
+Add the PyTorch Korean Users Group's **읽을거리&정보공유** forum (`https://discuss.pytorch.kr/c/news`) as a first-class source for the weekly newsletter research pipeline. The research agent must receive recent forum topics alongside Tavily, Hacker News, and official-blog results, then select interesting newsletter topics from the combined candidate pool.
+
+For each forum post, retain both the Korean forum summary and the original/primary source URL that the forum post is based on.
+
+## Scope
+
+### In scope
+
+- Collect forum topics published during the seven days ending on `publication_date`.
+- Extract each topic's title, forum URL, publication date, tags, first two text paragraphs, and primary-source URL.
+- Integrate the results into `collect_weekly_research` as a new category.
+- Normalize, deduplicate, rank, truncate, summarize, persist, and report forum candidates through the existing research pipeline.
+- Add deterministic unit tests and an opt-in live integration test.
+
+### Out of scope
+
+- Browser/UI automation or simulated infinite scrolling.
+- Scraping replies beyond the original post.
+- Changing the newsletter topic-selector policy or reserving a forum-specific quota.
+- Fetching the original external source's full content as part of this feature.
+- Authentication, posting, commenting, or other write operations on PyTorchKR.
+
+## Approach Selection
+
+### Recommended: Discourse JSON API
+
+Use the forum's public Discourse endpoints:
+
+- `GET /c/news/14/l/latest.json?page=N` for paginated topic listings.
+- `GET /t/{topic_id}.json` for a topic's original post, rendered HTML, and outbound-link metadata.
+
+The UI's scroll-driven loading is backed by this pagination. Direct JSON calls are therefore more reliable and testable than browser scrolling, avoid rendering/timing concerns, and expose the full original post needed for the requested two-paragraph excerpt and primary source URL.
+
+### Alternatives considered
+
+1. **Browser scroll + HTML scraping** — mirrors the visual page but is slower and more fragile because dynamic loading, selectors, and timing can change.
+2. **Category RSS feed** — supplies title, date, link, and often a full description, but is blocked for generic bots in the site's `robots.txt` and is limited to 25 items/page. It also does not expose outbound-link metadata as reliably as topic JSON.
+3. **Listing JSON only** — cheap, but insufficient because it lacks the forum post prose and primary-source link.
+
+## Architecture
+
+### New source adapter
+
+Add `search_pytorch_kr_forum(publication_date: str) -> str` in `src/tools/search_tools.py`.
+
+It returns a JSON string with the same error-as-data convention as the existing search tools. A successful item has this source-specific shape:
+
+```json
+{
+  "title": "…",
+  "forum_url": "https://discuss.pytorch.kr/t/{slug}/{id}",
+  "original_url": "https://primary-source.example/…",
+  "content": "first paragraph\n\nsecond paragraph",
+  "published_at": "YYYY-MM-DD",
+  "tags": ["…"]
+}
+```
+
+`original_url` falls back to `forum_url` when no qualifying external source can be identified.
+
+### Pipeline integration
+
+Add a `pytorch_kr_community` item to `RESEARCH_QUERY_PLAN` with a new `pytorch_kr` tool type. Extend `_run_searches` to call the forum adapter and `_normalize_candidates` to map its source-specific records to the existing candidate schema.
+
+Normalized forum candidates use:
+
+- `source`: `"discuss.pytorch.kr"`
+- `url`: the forum URL, preserving the Korean community context
+- `original_url`: the extracted external/primary source
+- `published_at`: the forum topic's `created_at` date
+- `summary`: first two meaningful forum paragraphs
+- `category`: `"pytorch_kr_community"`
+- `topic_type`: `"main"` by default
+- `prefetched_content`: the two-paragraph forum excerpt, retained internally for later batch enrichment
+- `fetched`: initially `false`; it becomes `true` only when the candidate is selected for the existing shared enrichment budget
+
+Forum candidates compete normally in the existing deduplication, shared ranking, and `max_search_results` truncation. They receive **no reserved quota** and do not bypass the shared `max_fetches`/summarization policy. When a forum candidate is among the shared top `max_fetches`, `_fetch_top_candidates` uses its `prefetched_content` instead of re-fetching the forum page and passes that excerpt to the existing batch summarizer. This keeps the requested per-topic content collection while preserving the current bounded LLM-enrichment budget.
+
+`original_url` remains an optional additive candidate field; existing consumers that do not use it remain compatible. The research-agent report will be updated to show both the forum URL and the primary source URL when they differ, so the article writer can use the original source for fact verification.
+
+## Data Flow
+
+1. `collect_weekly_research(publication_date)` builds the usual query plan, now including `pytorch_kr_community`.
+2. `search_pytorch_kr_forum` computes the inclusive interval `[publication_date - 7 days, publication_date]`.
+3. It fetches category-list JSON pages in descending recency order, skipping pinned topics and stopping when a page is older than the interval. A fixed page limit protects against unexpected pagination behavior.
+4. For each in-range topic, it requests `/t/{id}.json` sequentially using the existing browser-like headers and a modest inter-request delay.
+5. It parses the original post's `cooked` HTML:
+   - select the first two non-empty, meaningful `<p>` elements;
+   - discard image-only, empty, and boilerplate-only paragraphs;
+   - convert them to clean plain text;
+   - locate primary URLs by preferring `data-onebox-src` external URLs, then external `<a href>` links;
+   - exclude internal forum, image/upload, anchor, signup, social-notification, and footer/community-promotion links.
+6. The adapter returns source records, with per-topic failures captured rather than failing the entire source.
+7. `research_collector` normalizes results, deduplicates equivalent titles/URLs, applies the existing date filter and shared ranking, then enriches surviving fetched candidates with the existing batch summarizer.
+8. Raw results and final candidates continue to be persisted under `artifacts/research/{publication_date}/`.
+
+## Primary Source Extraction Rules
+
+The field represents the external resource that most directly supports the forum post:
+
+1. Prefer the first external `data-onebox-src` URL in document order.
+2. If none exists, use the first external non-image hyperlink in the original post body.
+3. Reject links to `discuss.pytorch.kr`, uploads/media, anchors, the PyTorchKR home page, signup pages, Telegram/notification pages, and the standard forum footer.
+4. If no qualifying URL exists, set `original_url` to the topic's own forum URL.
+
+The original source is preserved for citation and deeper article verification; it is not automatically fetched by this new adapter.
+
+## Error Handling and Courtesy
+
+- Use the established `httpx.Client`, existing `_HEADERS`, a 30-second timeout, and redirect following.
+- Handle category-level network/invalid-JSON failures as structured source errors.
+- Handle topic-detail failures individually: skip only the failed post and record a descriptive error.
+- Stop pagination on an empty page, a page whose non-pinned topics are all older than the cutoff, or the bounded maximum page count.
+- Request details sequentially with a short delay to avoid burst traffic to the community forum.
+- Never create, edit, or authenticate against forum content.
+
+## Testing
+
+Add tests following the project's existing `tests/test_blog_scraping.py` and `tests/test_research_collector.py` conventions.
+
+### Unit tests
+
+- Date-window boundaries, including publication-day inclusion and exclusion of topics older than seven days.
+- Multi-page pagination and early stopping.
+- Pinned-topic exclusion.
+- First-two-meaningful-paragraph extraction, including leading image-only paragraphs.
+- Primary-source selection precedence: onebox URL, plain external link fallback, and forum-URL fallback.
+- Rejection of internal/footer/media URLs.
+- Per-topic failure isolation and source-level error reporting.
+- Query-plan coverage, search dispatch, and normalized candidate fields for the new category.
+
+### Integration test
+
+Add an `@pytest.mark.integration` test that calls the live public forum for a known date window and asserts that returned entries have a title, forum URL, date, two-paragraph content when available, and a populated primary-source field. The default test suite remains offline.
+
+## Acceptance Criteria
+
+1. `collect_weekly_research` includes a `pytorch_kr_community` source entry and can run when this source is available or unavailable without breaking the other sources.
+2. Only non-pinned topics published within the inclusive seven-day period ending on `publication_date` are returned.
+3. Each eligible topic carries its title, forum URL, `published_at`, tags, cleaned first two meaningful paragraphs, and `original_url` (falling back to the forum URL).
+4. Original-source selection prioritizes an external onebox source and excludes PyTorchKR/internal, media, anchor, and footer links.
+5. Forum candidates compete equally in existing deduplication, ranking, and truncation; no reserved quota is introduced.
+6. The research agent's report shows the forum source and primary-source URL where distinct.
+7. Unit tests cover parsing, pagination, date boundaries, error isolation, and collector integration; the non-integration suite passes.
+8. A live integration test is marked `integration` and is not required for ordinary offline test runs.

--- a/src/config.py
+++ b/src/config.py
@@ -92,12 +92,12 @@ candidates 목록을 바탕으로 아래 형식의 번호가 매겨진 보고서
 1. 제목
 2. 요약 (2-3문장) — candidates의 summary, key_facts, why_it_matters를 활용하세요
 3. 출처 URL — PyTorch-KR 후보는 포럼 출처 URL: <url>로 표시하세요
-4. 원문/주요 출처 URL: <original_url> — PyTorch-KR 후보에서 original_url이 포럼 URL과 다를 때만 표시하고,
-   기사 작성 시 사실 검증은 이 URL을 우선 사용하세요
-5. 발표/게시 날짜 (published_at)
-6. 중요도 (높음/중간/낮음) — category가 real_world_usecases(실제 AI 활용 사례)이거나
+   - 원문/주요 출처 URL: <original_url> — PyTorch-KR 후보에서 original_url이 포럼 URL과 다를 때만 표시하고,
+     기사 작성 시 사실 검증은 이 URL을 우선 사용하세요
+4. 발표/게시 날짜 (published_at)
+5. 중요도 (높음/중간/낮음) — category가 real_world_usecases(실제 AI 활용 사례)이거나
    why_it_matters가 강한 후보는 높음으로 표시하세요
-7. 카테고리 (모델발표/에이전트/연구/도구/산업동향/정책/학습자료/커뮤니티)
+6. 카테고리 (모델발표/에이전트/연구/도구/산업동향/정책/학습자료/커뮤니티)
 
 ## 우선순위
 실제 AI 활용 사례(개인·기업이 AI 에이전트/LLM으로 구체적 문제를 해결한 사례)는

--- a/src/config.py
+++ b/src/config.py
@@ -73,10 +73,12 @@ RESEARCH_AGENT_PROMPT = """당신은 AI와 LLM 분야의 리서치 전문가입�
 ### 1단계: 압축 리서치 수집 (필수)
 `collect_weekly_research(publication_date=...)`를 호출하여 이번 주 AI/LLM 뉴스 후보 목록을 가져오세요.
 이 도구는 모델 발표, AI 에이전트/자동화, 연구 논문, 도구/인프라, 산업 동향, 정책/사회, 학습 자료,
-그리고 실제 AI 활용 사례(Show HN 검색 포함)와 공식 블로그(OpenAI/Anthropic/DeepMind)를
-검색하고, 중복 제거·날짜 필터링·요약을 거친 압축된 후보(candidates) 목록을 반환합니다.
+실제 AI 활용 사례(Show HN 검색 포함), 공식 블로그(OpenAI/Anthropic/DeepMind), 그리고
+PyTorch-KR 포럼의 읽을거리·정보공유 게시글을 검색하고, 중복 제거·날짜 필터링·요약을 거친
+압축된 후보(candidates) 목록을 반환합니다.
 각 후보는 title, url, source, published_at, summary, key_facts, why_it_matters,
-topic_type, category 필드를 포함합니다.
+topic_type, category 필드를 포함합니다. PyTorch-KR 후보에는 선택적으로 original_url도 있으며,
+url은 한국 커뮤니티 맥락을 보존하는 포럼 출처 URL이고 original_url은 사실 검증에 사용할 원문/주요 출처입니다.
 
 ### 2단계: 선택적 원문 확인
 중요도가 높은 후보 중 `fetched`가 false이거나 summary가 빈약한 후보에 대해서는
@@ -89,11 +91,13 @@ candidates 목록을 바탕으로 아래 형식의 번호가 매겨진 보고서
 각 토픽에 대해 다음 정보를 제공하세요:
 1. 제목
 2. 요약 (2-3문장) — candidates의 summary, key_facts, why_it_matters를 활용하세요
-3. 출처 URL
-4. 발표/게시 날짜 (published_at)
-5. 중요도 (높음/중간/낮음) — category가 real_world_usecases(실제 AI 활용 사례)이거나
+3. 출처 URL — PyTorch-KR 후보는 포럼 출처 URL: <url>로 표시하세요
+4. 원문/주요 출처 URL: <original_url> — PyTorch-KR 후보에서 original_url이 포럼 URL과 다를 때만 표시하고,
+   기사 작성 시 사실 검증은 이 URL을 우선 사용하세요
+5. 발표/게시 날짜 (published_at)
+6. 중요도 (높음/중간/낮음) — category가 real_world_usecases(실제 AI 활용 사례)이거나
    why_it_matters가 강한 후보는 높음으로 표시하세요
-6. 카테고리 (모델발표/에이전트/연구/도구/산업동향/정책/학습자료)
+7. 카테고리 (모델발표/에이전트/연구/도구/산업동향/정책/학습자료/커뮤니티)
 
 ## 우선순위
 실제 AI 활용 사례(개인·기업이 AI 에이전트/LLM으로 구체적 문제를 해결한 사례)는

--- a/src/tools/research_collector.py
+++ b/src/tools/research_collector.py
@@ -29,9 +29,9 @@ CATEGORY_TOPIC_TYPE: dict[str, str] = {
 }
 DEFAULT_TOPIC_TYPE = "main"
 
-# Query plan derived from the 8 categories in RESEARCH_AGENT_PROMPT, plus a
-# 9th "official_blogs" source-routing category. {year}/{month}/{month_en}
-# placeholders are filled by _build_query_plan() from publication_date.
+# Query plan derived from the 8 categories in RESEARCH_AGENT_PROMPT, plus 2
+# source-routing categories: "official_blogs" and PyTorch-KR (10 total).
+# {year}/{month}/{month_en} placeholders are filled by _build_query_plan() from publication_date.
 RESEARCH_QUERY_PLAN: list[dict] = [
     {"category": "model_releases", "tool": "tavily", "query": "{year}년 {month}월 AI 모델 출시"},
     {"category": "model_releases", "tool": "tavily", "query": "{month_en} {year} new LLM model release"},

--- a/src/tools/research_collector.py
+++ b/src/tools/research_collector.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from urllib.parse import urlparse
 
-from .search_tools import search_ai_news, search_hackernews
+from .search_tools import search_ai_news, search_hackernews, search_pytorch_kr_forum
 from .content_tools import fetch_article_content, fetch_official_blog_posts
 
 
@@ -45,6 +45,7 @@ RESEARCH_QUERY_PLAN: list[dict] = [
     {"category": "real_world_usecases", "tool": "hn", "query": "Show HN AI agent"},
     {"category": "real_world_usecases", "tool": "tavily", "query": '"AI agent" deployed production results {year}'},
     {"category": "official_blogs", "tool": "blog", "query": None},
+    {"category": "pytorch_kr_community", "tool": "pytorch_kr", "query": None},
 ]
 
 
@@ -103,6 +104,13 @@ def _run_searches(query_plan: list[dict], publication_date: str) -> tuple[list[d
                     for source_posts in blog_result.get("posts", {}).values()
                     for post in source_posts
                 ]
+            elif tool == "pytorch_kr":
+                forum_result = json.loads(search_pytorch_kr_forum(publication_date))
+                for forum_error in forum_result.get("errors", []):
+                    errors.append(f"{category}/{tool}: {forum_error}")
+                forum_posts = forum_result.get("posts", [])
+                if isinstance(forum_posts, list):
+                    items = forum_posts
         except Exception as exc:
             errors.append(f"{category}/{tool}: {exc}")
             items = []
@@ -137,6 +145,8 @@ def _normalize_candidates(raw_results: list[dict]) -> list[dict]:
         topic_type = CATEGORY_TOPIC_TYPE.get(category, DEFAULT_TOPIC_TYPE)
 
         for item in result["items"]:
+            original_url = None
+            prefetched_content = None
             if tool == "tavily":
                 url = item.get("url", "")
                 title = item.get("title", "")
@@ -160,6 +170,15 @@ def _normalize_candidates(raw_results: list[dict]) -> list[dict]:
                 score = 0.0
                 summary = item.get("description", "")
                 source = item.get("source") or urlparse(url).netloc
+            elif tool == "pytorch_kr":
+                url = item.get("forum_url", "")
+                title = item.get("title", "")
+                published_at = item.get("published_at")
+                score = 0.0
+                summary = item.get("content", "")
+                source = "discuss.pytorch.kr"
+                original_url = item.get("original_url", url)
+                prefetched_content = summary
             else:
                 continue
 
@@ -171,7 +190,7 @@ def _normalize_candidates(raw_results: list[dict]) -> list[dict]:
             if not published_at:
                 score -= 0.5
 
-            candidates.append({
+            candidate = {
                 "title": title,
                 "url": url,
                 "source": source,
@@ -183,7 +202,11 @@ def _normalize_candidates(raw_results: list[dict]) -> list[dict]:
                 "category": category,
                 "score": round(score, 3),
                 "fetched": False,
-            })
+            }
+            if original_url is not None:
+                candidate["original_url"] = original_url
+                candidate["prefetched_content"] = prefetched_content
+            candidates.append(candidate)
 
     return candidates
 
@@ -268,6 +291,11 @@ def _fetch_top_candidates(candidates: list[dict], max_fetches: int, max_chars_pe
     fetched_content: dict[str, str] = {}
 
     for candidate in candidates[:max_fetches]:
+        prefetched_content = candidate.get("prefetched_content")
+        if prefetched_content:
+            fetched_content[candidate["url"]] = prefetched_content[:max_chars_per_source]
+            candidate["fetched"] = True
+            continue
         try:
             result = json.loads(fetch_article_content(candidate["url"]))
         except Exception:
@@ -453,10 +481,11 @@ def collect_weekly_research(
 ) -> str:
     """Collect and compact this week's AI/LLM research candidates.
 
-    Searches AI news (Tavily), Hacker News, and official AI lab blogs across
-    a fixed set of research categories, deduplicates and date-filters the
-    results, fetches and summarizes the top-ranked candidates, and persists
-    raw and structured artifacts under artifacts/research/{publication_date}/.
+    Searches AI news (Tavily), Hacker News, official AI lab blogs, and the
+    PyTorch-KR community across a fixed set of research categories,
+    deduplicates and date-filters the results, fetches and summarizes the
+    top-ranked candidates, and persists raw and structured artifacts under
+    artifacts/research/{publication_date}/.
 
     Args:
         publication_date: Newsletter publication date in YYYY-MM-DD format.

--- a/src/tools/research_collector.py
+++ b/src/tools/research_collector.py
@@ -177,7 +177,7 @@ def _normalize_candidates(raw_results: list[dict]) -> list[dict]:
                 score = 0.0
                 summary = item.get("content", "")
                 source = "discuss.pytorch.kr"
-                original_url = item.get("original_url", url)
+                original_url = item.get("original_url") or url
                 prefetched_content = summary
             else:
                 continue
@@ -292,7 +292,7 @@ def _fetch_top_candidates(candidates: list[dict], max_fetches: int, max_chars_pe
 
     for candidate in candidates[:max_fetches]:
         prefetched_content = candidate.get("prefetched_content")
-        if prefetched_content:
+        if prefetched_content is not None:
             fetched_content[candidate["url"]] = prefetched_content[:max_chars_per_source]
             candidate["fetched"] = True
             continue
@@ -481,11 +481,10 @@ def collect_weekly_research(
 ) -> str:
     """Collect and compact this week's AI/LLM research candidates.
 
-    Searches AI news (Tavily), Hacker News, official AI lab blogs, and the
-    PyTorch-KR community across a fixed set of research categories,
-    deduplicates and date-filters the results, fetches and summarizes the
-    top-ranked candidates, and persists raw and structured artifacts under
-    artifacts/research/{publication_date}/.
+    Searches AI news (Tavily), Hacker News, and official AI lab blogs across
+    a fixed set of research categories, deduplicates and date-filters the
+    results, fetches and summarizes the top-ranked candidates, and persists
+    raw and structured artifacts under artifacts/research/{publication_date}/.
 
     Args:
         publication_date: Newsletter publication date in YYYY-MM-DD format.

--- a/src/tools/search_tools.py
+++ b/src/tools/search_tools.py
@@ -206,6 +206,8 @@ def _extract_pytorch_kr_post_fields(cooked: str, forum_url: str) -> tuple[str, s
             return "\n\n".join(paragraphs), source_url.strip()
 
     for anchor in soup.find_all("a", href=True):
+        if anchor.find_parent("footer") is not None:
+            continue
         source_url = anchor.get("href")
         if _is_pytorch_kr_primary_source(source_url):
             return "\n\n".join(paragraphs), source_url.strip()

--- a/src/tools/search_tools.py
+++ b/src/tools/search_tools.py
@@ -30,6 +30,12 @@ _PYTORCH_KR_BLOCKED_HOSTS = {
     "discuss-noti.pytorch.kr",
     "www.discourse.org",
 }
+_PYTORCH_KR_SIGNUP_PATHS = {
+    "/signup",
+    "/register",
+    "/login",
+    "/auth",
+}
 _PYTORCH_KR_MEDIA_EXTENSIONS = {
     ".avif", ".gif", ".jpeg", ".jpg", ".mov", ".mp3", ".mp4",
     ".pdf", ".png", ".svg", ".webm", ".webp",
@@ -38,6 +44,7 @@ _PYTORCH_KR_BOILERPLATE_PARAGRAPHS = {
     "powered by discourse",
     "pytorch korea users group",
 }
+
 
 def search_ai_news(query: str, max_results: int = 10, article_date: str | None = None) -> str:
     """Search for AI/LLM related news using Tavily API.
@@ -184,6 +191,8 @@ def _is_pytorch_kr_primary_source(url: object) -> bool:
         return False
     if any(segment in path for segment in ("/upload/", "/uploads/", "/image/", "/images/", "/media/")):
         return False
+    if any(path.startswith(sp) for sp in _PYTORCH_KR_SIGNUP_PATHS):
+        return False
     return not path.endswith(tuple(_PYTORCH_KR_MEDIA_EXTENSIONS))
 
 
@@ -201,12 +210,18 @@ def _extract_pytorch_kr_post_fields(cooked: str, forum_url: str) -> tuple[str, s
             break
 
     for onebox in soup.find_all(attrs={"data-onebox-src": True}):
+        if onebox.find_parent("footer") is not None:
+            continue
+        if onebox.find_parent(class_="footer") is not None:
+            continue
         source_url = onebox.get("data-onebox-src")
         if _is_pytorch_kr_primary_source(source_url):
             return "\n\n".join(paragraphs), source_url.strip()
 
     for anchor in soup.find_all("a", href=True):
         if anchor.find_parent("footer") is not None:
+            continue
+        if anchor.find_parent(class_="footer") is not None:
             continue
         source_url = anchor.get("href")
         if _is_pytorch_kr_primary_source(source_url):

--- a/src/tools/search_tools.py
+++ b/src/tools/search_tools.py
@@ -1,10 +1,41 @@
 """Search tools for gathering AI/LLM news and information."""
 
-import os
 import json
-import httpx
+import os
+import time
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
+
+import httpx
+from bs4 import BeautifulSoup
 from tavily import TavilyClient
+
+
+PYTORCH_KR_BASE_URL = "https://discuss.pytorch.kr"
+PYTORCH_KR_NEWS_CATEGORY_ID = 14
+PYTORCH_KR_MAX_PAGES = 5
+PYTORCH_KR_REQUEST_DELAY_SECONDS = 0.2
+PYTORCH_KR_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+}
+_PYTORCH_KR_BLOCKED_HOSTS = {
+    "pytorch.kr",
+    "t.me",
+    "discuss-noti.pytorch.kr",
+    "www.discourse.org",
+}
+_PYTORCH_KR_MEDIA_EXTENSIONS = {
+    ".avif", ".gif", ".jpeg", ".jpg", ".mov", ".mp3", ".mp4",
+    ".pdf", ".png", ".svg", ".webm", ".webp",
+}
+_PYTORCH_KR_BOILERPLATE_PARAGRAPHS = {
+    "powered by discourse",
+    "pytorch korea users group",
+}
 
 def search_ai_news(query: str, max_results: int = 10, article_date: str | None = None) -> str:
     """Search for AI/LLM related news using Tavily API.
@@ -121,3 +152,210 @@ def search_hackernews(query: str, num_results: int = 10, publication_date: str |
 
     except Exception as e:
         return json.dumps({"error": str(e)})
+
+
+def _parse_pytorch_kr_created_at(value: object) -> datetime | None:
+    """Parse the UTC timestamps emitted by Discourse topic listings."""
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def _is_pytorch_kr_primary_source(url: object) -> bool:
+    """Return whether a post link is an external, non-media primary source."""
+    if not isinstance(url, str) or not url.strip() or url.lstrip().startswith("#"):
+        return False
+
+    parsed = urlparse(url.strip())
+    host = (parsed.hostname or "").lower()
+    path = parsed.path.lower()
+    if parsed.scheme not in {"http", "https"} or not host:
+        return False
+    if host == "discuss.pytorch.kr" or host.endswith(".pytorch.kr"):
+        return False
+    if host in _PYTORCH_KR_BLOCKED_HOSTS or host.endswith(".t.me"):
+        return False
+    if host == "discourse.org" or host.endswith(".discourse.org"):
+        return False
+    if any(segment in path for segment in ("/upload/", "/uploads/", "/image/", "/images/", "/media/")):
+        return False
+    return not path.endswith(tuple(_PYTORCH_KR_MEDIA_EXTENSIONS))
+
+
+def _extract_pytorch_kr_post_fields(cooked: str, forum_url: str) -> tuple[str, str]:
+    """Extract a short forum excerpt and the best external source link."""
+    soup = BeautifulSoup(cooked or "", "html.parser")
+
+    paragraphs: list[str] = []
+    for paragraph in soup.find_all("p"):
+        text = paragraph.get_text(" ", strip=True)
+        if not text or text.casefold() in _PYTORCH_KR_BOILERPLATE_PARAGRAPHS:
+            continue
+        paragraphs.append(text)
+        if len(paragraphs) == 2:
+            break
+
+    for onebox in soup.find_all(attrs={"data-onebox-src": True}):
+        source_url = onebox.get("data-onebox-src")
+        if _is_pytorch_kr_primary_source(source_url):
+            return "\n\n".join(paragraphs), source_url.strip()
+
+    for anchor in soup.find_all("a", href=True):
+        source_url = anchor.get("href")
+        if _is_pytorch_kr_primary_source(source_url):
+            return "\n\n".join(paragraphs), source_url.strip()
+
+    return "\n\n".join(paragraphs), forum_url
+
+
+def _fetch_pytorch_kr_forum_posts(
+    client: httpx.Client,
+    publication_date: str,
+    *,
+    max_pages: int = PYTORCH_KR_MAX_PAGES,
+    request_delay_seconds: float = PYTORCH_KR_REQUEST_DELAY_SECONDS,
+) -> tuple[list[dict], list[str]]:
+    """Collect recent non-pinned PyTorch-KR news topics through Discourse JSON."""
+    try:
+        end = datetime.strptime(publication_date, "%Y-%m-%d").replace(
+            hour=23,
+            minute=59,
+            second=59,
+        )
+    except (TypeError, ValueError) as error:
+        return [], [f"Invalid publication_date {publication_date!r}: {error}"]
+
+    start = end.replace(hour=0, minute=0, second=0) - timedelta(days=7)
+    listing_url = (
+        f"{PYTORCH_KR_BASE_URL}/c/news/{PYTORCH_KR_NEWS_CATEGORY_ID}/l/latest.json"
+    )
+    seen_topic_ids: set[str] = set()
+    eligible_topics: list[tuple[dict, datetime]] = []
+
+    for page in range(max_pages):
+        try:
+            response = client.get(listing_url, params={"page": page})
+            response.raise_for_status()
+            listing = response.json()
+            topic_list = listing.get("topic_list", {})
+            topics = topic_list.get("topics", [])
+            if not isinstance(topics, list):
+                raise ValueError("listing topic_list.topics is not a list")
+        except Exception as error:
+            return [], [f"PyTorch-KR listing page {page} failed: {error}"]
+
+        if not topics:
+            break
+
+        parseable_non_pinned_dates: list[datetime] = []
+        for topic in topics:
+            if not isinstance(topic, dict):
+                continue
+
+            created_at = _parse_pytorch_kr_created_at(topic.get("created_at"))
+            if not topic.get("pinned") and created_at is not None:
+                parseable_non_pinned_dates.append(created_at)
+
+            topic_id = topic.get("id")
+            if topic_id is None:
+                continue
+            topic_id_key = str(topic_id)
+            if topic_id_key in seen_topic_ids:
+                continue
+            seen_topic_ids.add(topic_id_key)
+
+            if topic.get("pinned") or created_at is None:
+                continue
+            if start <= created_at <= end:
+                eligible_topics.append((topic, created_at))
+
+        if (
+            parseable_non_pinned_dates
+            and all(created_at < start for created_at in parseable_non_pinned_dates)
+        ):
+            break
+        if not topic_list.get("more_topics_url"):
+            break
+
+    posts: list[dict] = []
+    errors: list[str] = []
+    for index, (topic, created_at) in enumerate(eligible_topics):
+        topic_id = topic["id"]
+        slug = topic.get("slug", "")
+        forum_url = f"{PYTORCH_KR_BASE_URL}/t/{slug}/{topic_id}"
+        try:
+            response = client.get(f"{PYTORCH_KR_BASE_URL}/t/{topic_id}.json")
+            response.raise_for_status()
+            detail = response.json()
+            cooked = detail["post_stream"]["posts"][0]["cooked"]
+            if not isinstance(cooked, str):
+                raise ValueError("topic detail first post has no cooked HTML")
+            content, original_url = _extract_pytorch_kr_post_fields(cooked, forum_url)
+            tags = []
+            for tag in topic.get("tags", []):
+                if isinstance(tag, dict) and isinstance(tag.get("slug"), str):
+                    tags.append(tag["slug"])
+                elif isinstance(tag, str):
+                    tags.append(tag)
+            posts.append(
+                {
+                    "title": topic.get("title", ""),
+                    "forum_url": forum_url,
+                    "original_url": original_url,
+                    "content": content,
+                    "published_at": created_at.strftime("%Y-%m-%d"),
+                    "tags": tags,
+                }
+            )
+        except Exception as error:
+            errors.append(f"PyTorch-KR topic {topic_id} detail failed: {error}")
+
+        if request_delay_seconds > 0 and index < len(eligible_topics) - 1:
+            time.sleep(request_delay_seconds)
+
+    return posts, errors
+
+
+def search_pytorch_kr_forum(publication_date: str) -> str:
+    """Collect the inclusive seven-day PyTorch-KR news window as JSON data."""
+    try:
+        end = datetime.strptime(publication_date, "%Y-%m-%d")
+    except (TypeError, ValueError) as error:
+        return json.dumps(
+            {
+                "publication_date": publication_date,
+                "date_range": {"start": None, "end": None},
+                "posts": [],
+                "errors": [f"Invalid publication_date {publication_date!r}: {error}"],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    start = end - timedelta(days=7)
+    envelope = {
+        "publication_date": publication_date,
+        "date_range": {
+            "start": start.strftime("%Y-%m-%d"),
+            "end": end.strftime("%Y-%m-%d"),
+        },
+        "posts": [],
+        "errors": [],
+    }
+    try:
+        with httpx.Client(
+            timeout=30.0,
+            follow_redirects=True,
+            headers=PYTORCH_KR_HEADERS,
+        ) as client:
+            envelope["posts"], envelope["errors"] = _fetch_pytorch_kr_forum_posts(
+                client,
+                publication_date,
+            )
+    except Exception as error:
+        envelope["errors"] = [f"PyTorch-KR forum collection failed: {error}"]
+
+    return json.dumps(envelope, ensure_ascii=False, indent=2)

--- a/src/tools/search_tools.py
+++ b/src/tools/search_tools.py
@@ -25,6 +25,8 @@ PYTORCH_KR_HEADERS = {
 _PYTORCH_KR_BLOCKED_HOSTS = {
     "pytorch.kr",
     "t.me",
+    "telegram.me",
+    "telegram.org",
     "discuss-noti.pytorch.kr",
     "www.discourse.org",
 }
@@ -176,7 +178,7 @@ def _is_pytorch_kr_primary_source(url: object) -> bool:
         return False
     if host == "discuss.pytorch.kr" or host.endswith(".pytorch.kr"):
         return False
-    if host in _PYTORCH_KR_BLOCKED_HOSTS or host.endswith(".t.me"):
+    if host in _PYTORCH_KR_BLOCKED_HOSTS or host.endswith((".t.me", ".telegram.me", ".telegram.org")):
         return False
     if host == "discourse.org" or host.endswith(".discourse.org"):
         return False

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -44,6 +44,13 @@ def test_research_prompt_has_usecase_category():
     assert "Show HN" in RESEARCH_AGENT_PROMPT
 
 
+def test_research_prompt_explains_forum_and_primary_source_urls():
+    """Forum candidates need both community context and primary-source citation guidance."""
+    assert "original_url" in RESEARCH_AGENT_PROMPT
+    assert "포럼 출처 URL" in RESEARCH_AGENT_PROMPT
+    assert "원문/주요 출처 URL" in RESEARCH_AGENT_PROMPT
+
+
 def test_topic_selector_prioritizes_usecases():
     """Topic selector must be told to rank use-case stories highly."""
     assert "활용 사례" in TOPIC_SELECTOR_PROMPT or "실제" in TOPIC_SELECTOR_PROMPT

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -45,10 +45,23 @@ def test_research_prompt_has_usecase_category():
 
 
 def test_research_prompt_explains_forum_and_primary_source_urls():
-    """Forum candidates need both community context and primary-source citation guidance."""
-    assert "original_url" in RESEARCH_AGENT_PROMPT
+    """Forum candidates preserve community context while prioritizing distinct primary sources."""
+    # The optional field and community context are explicit in the candidate contract.
+    assert "선택적으로 original_url" in RESEARCH_AGENT_PROMPT
     assert "포럼 출처 URL" in RESEARCH_AGENT_PROMPT
-    assert "원문/주요 출처 URL" in RESEARCH_AGENT_PROMPT
+
+    # The report keeps mandatory fields consecutively numbered even when a
+    # distinct primary source is absent.
+    assert "3. 출처 URL" in RESEARCH_AGENT_PROMPT
+    assert "4. 발표/게시 날짜" in RESEARCH_AGENT_PROMPT
+    assert "5. 중요도" in RESEARCH_AGENT_PROMPT
+    assert "6. 카테고리" in RESEARCH_AGENT_PROMPT
+
+    # A primary/original URL is separately reported only when it differs from
+    # the forum URL, and it takes priority for factual verification.
+    assert "- 원문/주요 출처 URL: <original_url>" in RESEARCH_AGENT_PROMPT
+    assert "original_url이 포럼 URL과 다를 때만 표시" in RESEARCH_AGENT_PROMPT
+    assert "사실 검증은 이 URL을 우선 사용" in RESEARCH_AGENT_PROMPT
 
 
 def test_topic_selector_prioritizes_usecases():

--- a/tests/test_pytorch_kr_collector.py
+++ b/tests/test_pytorch_kr_collector.py
@@ -115,6 +115,26 @@ def test_normalize_candidates_preserves_forum_context_and_primary_source():
     }]
 
 
+def test_normalize_candidates_falls_back_to_forum_url_for_falsey_original_url():
+    forum_url = "https://discuss.pytorch.kr/t/forum-item/1"
+
+    for original_url in (None, ""):
+        candidates = _normalize_candidates([{
+            "category": "pytorch_kr_community",
+            "tool": "pytorch_kr",
+            "query": None,
+            "items": [{
+                "title": "Forum Item",
+                "forum_url": forum_url,
+                "original_url": original_url,
+                "content": "첫 문단",
+                "published_at": "2026-06-12",
+            }],
+        }])
+
+        assert candidates[0]["original_url"] == forum_url
+
+
 def test_fetch_top_candidates_uses_prefetched_forum_excerpt_without_refetching(monkeypatch):
     forum_url = "https://discuss.pytorch.kr/t/forum-item/1"
     candidates = [

--- a/tests/test_pytorch_kr_collector.py
+++ b/tests/test_pytorch_kr_collector.py
@@ -159,3 +159,26 @@ def test_fetch_top_candidates_uses_prefetched_forum_excerpt_without_refetching(m
     assert fetched_content == {forum_url: "첫 문단\n\n둘째"}
     assert candidates[0]["fetched"] is True
     assert calls == []
+
+
+def test_fetch_top_candidates_keeps_empty_prefetched_content_without_refetching(monkeypatch):
+    forum_url = "https://discuss.pytorch.kr/t/forum-item/empty"
+    candidates = [{
+        "title": "Forum Item",
+        "url": forum_url,
+        "prefetched_content": "",
+        "fetched": False,
+    }]
+    calls = []
+
+    def fake_fetch_article_content(url):
+        calls.append(url)
+        return json.dumps({"content": "unexpected generic fetch"})
+
+    monkeypatch.setattr("src.tools.research_collector.fetch_article_content", fake_fetch_article_content)
+
+    fetched_content = _fetch_top_candidates(candidates, max_fetches=1, max_chars_per_source=8)
+
+    assert fetched_content == {forum_url: ""}
+    assert candidates[0]["fetched"] is True
+    assert calls == []

--- a/tests/test_pytorch_kr_collector.py
+++ b/tests/test_pytorch_kr_collector.py
@@ -1,0 +1,141 @@
+"""Integration contracts for PyTorch-KR records in the research collector."""
+
+import json
+
+from src.tools.research_collector import _fetch_top_candidates, _normalize_candidates, _run_searches
+
+
+def test_run_searches_routes_pytorch_kr_envelope_to_community_category(monkeypatch):
+    def fake_search_pytorch_kr_forum(publication_date):
+        return json.dumps({
+            "publication_date": publication_date,
+            "posts": [{
+                "title": "Forum Item",
+                "forum_url": "https://discuss.pytorch.kr/t/forum-item/1",
+                "original_url": "https://github.com/example/project",
+                "content": "첫 문단\n\n둘째 문단",
+                "published_at": "2026-06-12",
+                "tags": ["llm", "agent"],
+            }],
+        })
+
+    monkeypatch.setattr(
+        "src.tools.research_collector.search_pytorch_kr_forum",
+        fake_search_pytorch_kr_forum,
+    )
+
+    raw_results, errors = _run_searches(
+        [{"category": "pytorch_kr_community", "tool": "pytorch_kr", "query": None}],
+        "2026-06-17",
+    )
+
+    assert errors == []
+    assert raw_results == [{
+        "category": "pytorch_kr_community",
+        "tool": "pytorch_kr",
+        "query": None,
+        "items": [{
+            "title": "Forum Item",
+            "forum_url": "https://discuss.pytorch.kr/t/forum-item/1",
+            "original_url": "https://github.com/example/project",
+            "content": "첫 문단\n\n둘째 문단",
+            "published_at": "2026-06-12",
+            "tags": ["llm", "agent"],
+        }],
+    }]
+
+
+def test_run_searches_prefixes_pytorch_kr_envelope_errors_and_keeps_raw_items(monkeypatch):
+    def fake_search_pytorch_kr_forum(publication_date):
+        return json.dumps({
+            "publication_date": publication_date,
+            "posts": [],
+            "errors": ["forum backend unavailable"],
+        })
+
+    monkeypatch.setattr(
+        "src.tools.research_collector.search_pytorch_kr_forum",
+        fake_search_pytorch_kr_forum,
+    )
+
+    raw_results, errors = _run_searches(
+        [{"category": "pytorch_kr_community", "tool": "pytorch_kr", "query": None}],
+        "2026-06-17",
+    )
+
+    assert errors == ["pytorch_kr_community/pytorch_kr: forum backend unavailable"]
+    assert raw_results[0]["items"] == []
+
+
+def test_run_searches_isolates_malformed_pytorch_kr_response(monkeypatch):
+    monkeypatch.setattr(
+        "src.tools.research_collector.search_pytorch_kr_forum",
+        lambda publication_date: "not valid json",
+    )
+
+    raw_results, errors = _run_searches(
+        [{"category": "pytorch_kr_community", "tool": "pytorch_kr", "query": None}],
+        "2026-06-17",
+    )
+
+    assert raw_results[0]["items"] == []
+    assert len(errors) == 1
+    assert errors[0].startswith("pytorch_kr_community/pytorch_kr:")
+
+
+def test_normalize_candidates_preserves_forum_context_and_primary_source():
+    candidates = _normalize_candidates([{
+        "category": "pytorch_kr_community",
+        "tool": "pytorch_kr",
+        "query": None,
+        "items": [{
+            "title": "Forum Item",
+            "forum_url": "https://discuss.pytorch.kr/t/forum-item/1",
+            "original_url": "https://github.com/example/project",
+            "content": "첫 문단\n\n둘째 문단",
+            "published_at": "2026-06-12",
+            "tags": ["llm", "agent"],
+        }],
+    }])
+
+    assert candidates == [{
+        "title": "Forum Item",
+        "url": "https://discuss.pytorch.kr/t/forum-item/1",
+        "original_url": "https://github.com/example/project",
+        "source": "discuss.pytorch.kr",
+        "published_at": "2026-06-12",
+        "summary": "첫 문단\n\n둘째 문단",
+        "prefetched_content": "첫 문단\n\n둘째 문단",
+        "key_facts": [],
+        "why_it_matters": "",
+        "topic_type": "main",
+        "category": "pytorch_kr_community",
+        "score": 0.0,
+        "fetched": False,
+    }]
+
+
+def test_fetch_top_candidates_uses_prefetched_forum_excerpt_without_refetching(monkeypatch):
+    forum_url = "https://discuss.pytorch.kr/t/forum-item/1"
+    candidates = [
+        {
+            "title": "Forum Item",
+            "url": forum_url,
+            "prefetched_content": "첫 문단\n\n둘째 문단",
+            "fetched": False,
+        },
+        {"title": "Other", "url": "https://example.com/other", "fetched": False},
+    ]
+    calls = []
+
+    def fake_fetch_article_content(url):
+        calls.append(url)
+        return json.dumps({"content": "other content"})
+
+    monkeypatch.setattr("src.tools.research_collector.fetch_article_content", fake_fetch_article_content)
+
+    fetched_content = _fetch_top_candidates(candidates, max_fetches=1, max_chars_per_source=8)
+
+    assert fetched_content == {forum_url: "첫 문단\n\n둘째"}
+    assert candidates[0]["fetched"] is True
+    assert calls == []

--- a/tests/test_pytorch_kr_forum.py
+++ b/tests/test_pytorch_kr_forum.py
@@ -321,7 +321,10 @@ def test_live_pytorch_kr_forum_returns_structured_posts():
     payload = json.loads(search_pytorch_kr_forum(publication_date))
 
     assert payload["publication_date"] == publication_date
-    assert payload["posts"]
+    assert payload["errors"] == []
+    if not payload["posts"]:
+        pytest.skip("PyTorch-KR forum returned no posts in the current seven-day window")
+
     post = payload["posts"][0]
     assert post["title"]
     assert post["forum_url"].startswith("https://discuss.pytorch.kr/t/")

--- a/tests/test_pytorch_kr_forum.py
+++ b/tests/test_pytorch_kr_forum.py
@@ -1,0 +1,294 @@
+"""Red tests defining the PyTorch-KR Discourse research-source adapter."""
+
+import json
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+
+from src.tools.search_tools import (
+    _extract_pytorch_kr_post_fields,
+    _fetch_pytorch_kr_forum_posts,
+    search_pytorch_kr_forum,
+)
+
+
+PUBLICATION_DATE = "2026-07-15"
+FORUM_BASE_URL = "https://discuss.pytorch.kr"
+LISTING_PATH = "/c/news/14/l/latest.json"
+
+SAMPLE_TOPIC_HTML = """\
+<p><img src="/uploads/default/original/1X/cover.png" alt="cover"></p>
+<p>첫 번째 실제 본문입니다.</p>
+<p>두 번째 실제 본문입니다.</p>
+<aside class="onebox" data-onebox-src="https://github.com/example/project">
+  <header class="source"><a href="https://github.com/example/project">project</a></header>
+</aside>
+<footer>
+  <a href="https://discuss.pytorch.kr">PyTorchKR</a>
+  <a href="https://www.discourse.org">Powered by Discourse</a>
+</footer>
+"""
+
+SAMPLE_PLAIN_LINK_HTML = """\
+<p>논문을 소개합니다.</p>
+<p><a href="https://arxiv.org/abs/2601.00001">논문 원문</a>을 참고하세요.</p>
+"""
+
+SAMPLE_NO_SOURCE_HTML = """\
+<p>외부 원문이 없는 안내입니다.</p>
+<p>토론은 포럼에서 이어집니다.</p>
+"""
+
+SAMPLE_INELIGIBLE_LINKS_HTML = """\
+<p>유효한 원문 링크가 없는 게시글입니다.</p>
+<p>관련 커뮤니티 링크만 있습니다.</p>
+<a href="https://discuss.pytorch.kr/t/related/8">포럼 내부 글</a>
+<a href="https://discuss.pytorch.kr/uploads/default/original/1X/image.png">업로드 이미지</a>
+<a href="#reply-1">댓글 앵커</a>
+<a href="https://discuss.pytorch.kr/signup">가입</a>
+<a href="https://pytorch.kr/">PyTorchKR 홈</a>
+<a href="https://t.me/pytorchkr">텔레그램</a>
+<footer>
+  <a href="https://discuss-noti.pytorch.kr/">알림</a>
+  <a href="https://www.discourse.org">Powered by Discourse</a>
+</footer>
+"""
+
+
+class FakeResponse:
+    """Small httpx-response stand-in for deterministic adapter tests."""
+
+    def __init__(self, payload, *, url: str, status_code: int = 200):
+        self._payload = payload
+        self.url = url
+        self.status_code = status_code
+
+    @property
+    def is_success(self) -> bool:
+        return 200 <= self.status_code < 400
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if not self.is_success:
+            request = httpx.Request("GET", self.url)
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError(
+                f"Server error {self.status_code} for url {self.url}",
+                request=request,
+                response=response,
+            )
+
+
+class RecordingForumClient:
+    """Routes Discourse listing/detail requests from inline fixture payloads."""
+
+    def __init__(self, listing_pages, topic_details):
+        self.listing_pages = listing_pages
+        self.topic_details = topic_details
+        self.requested_listing_pages = []
+        self.requested_topic_ids = []
+
+    def get(self, url, **kwargs):
+        parsed = urlparse(str(url))
+        if parsed.path == LISTING_PATH:
+            params = kwargs.get("params") or {}
+            page = int(parse_qs(parsed.query).get("page", [params.get("page", 0)])[0])
+            self.requested_listing_pages.append(page)
+            if page >= len(self.listing_pages):
+                raise AssertionError(f"unexpected listing page request: {page}")
+            return FakeResponse(self.listing_pages[page], url=str(url))
+
+        if parsed.path.startswith("/t/") and parsed.path.endswith(".json"):
+            topic_id = int(parsed.path.removesuffix(".json").rsplit("/", 1)[-1])
+            self.requested_topic_ids.append(topic_id)
+            response = self.topic_details[topic_id]
+            if isinstance(response, FakeResponse):
+                return response
+            return FakeResponse(response, url=str(url))
+
+        raise AssertionError(f"unexpected URL requested: {url}")
+
+
+class FailingForumClient:
+    """Context-managed client whose listing request fails at the HTTP boundary."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def get(self, url, **kwargs):
+        request = httpx.Request("GET", str(url))
+        raise httpx.ConnectError("forum unavailable", request=request)
+
+
+def _topic(topic_id, title, created_at, *, pinned=False, tags=None):
+    return {
+        "id": topic_id,
+        "slug": title.lower().replace(" ", "-"),
+        "title": title,
+        "created_at": created_at,
+        "pinned": pinned,
+        "tags": tags or [],
+    }
+
+
+def _detail(cooked: str):
+    return {"post_stream": {"posts": [{"cooked": cooked}]}}
+
+
+def _listing(topics, *, more_topics_url=None):
+    return {"topic_list": {"topics": topics, "more_topics_url": more_topics_url}}
+
+
+# ---------------------------------------------------------------------------
+# HTML extraction and primary-source selection
+# ---------------------------------------------------------------------------
+
+
+def test_extracts_two_meaningful_korean_paragraphs_and_onebox_source():
+    content, original_url = _extract_pytorch_kr_post_fields(
+        SAMPLE_TOPIC_HTML,
+        f"{FORUM_BASE_URL}/t/example/101",
+    )
+
+    assert content == "첫 번째 실제 본문입니다.\n\n두 번째 실제 본문입니다."
+    assert original_url == "https://github.com/example/project"
+
+
+def test_uses_external_arxiv_link_when_no_onebox_exists():
+    _, original_url = _extract_pytorch_kr_post_fields(
+        SAMPLE_PLAIN_LINK_HTML,
+        f"{FORUM_BASE_URL}/t/example/102",
+    )
+
+    assert original_url == "https://arxiv.org/abs/2601.00001"
+
+
+def test_falls_back_to_forum_url_when_no_eligible_external_source_exists():
+    forum_url = f"{FORUM_BASE_URL}/t/example/103"
+
+    _, original_url = _extract_pytorch_kr_post_fields(SAMPLE_NO_SOURCE_HTML, forum_url)
+
+    assert original_url == forum_url
+
+
+def test_rejects_internal_media_anchor_signup_home_telegram_and_footer_links():
+    forum_url = f"{FORUM_BASE_URL}/t/example/104"
+
+    _, original_url = _extract_pytorch_kr_post_fields(SAMPLE_INELIGIBLE_LINKS_HTML, forum_url)
+
+    assert original_url == forum_url
+
+
+# ---------------------------------------------------------------------------
+# Paginated Discourse collection and error isolation
+# ---------------------------------------------------------------------------
+
+
+def test_fetches_only_inclusive_non_pinned_window_and_stops_after_old_page():
+    in_window = _topic(
+        101,
+        "In Window",
+        "2026-07-15T09:00:00.000Z",
+        tags=[{"slug": "llm"}, "research"],
+    )
+    seven_day_boundary = _topic(102, "Seven Day Boundary", "2026-07-08T00:00:00.000Z")
+    old_topic = _topic(103, "Too Old", "2026-07-07T23:59:59.000Z")
+    pinned_topic = _topic(104, "Pinned", "2026-07-15T08:00:00.000Z", pinned=True)
+    page_one_old_topic = _topic(105, "Older Page", "2026-07-07T12:00:00.000Z")
+
+    client = RecordingForumClient(
+        [
+            _listing(
+                [in_window, seven_day_boundary, old_topic, pinned_topic],
+                more_topics_url="/c/news/14/l/latest?page=1",
+            ),
+            _listing([page_one_old_topic], more_topics_url="/c/news/14/l/latest?page=2"),
+        ],
+        {
+            101: _detail(SAMPLE_TOPIC_HTML),
+            102: _detail(SAMPLE_PLAIN_LINK_HTML),
+        },
+    )
+
+    posts, errors = _fetch_pytorch_kr_forum_posts(
+        client,
+        PUBLICATION_DATE,
+        max_pages=5,
+        request_delay_seconds=0,
+    )
+
+    assert errors == []
+    assert [post["title"] for post in posts] == ["In Window", "Seven Day Boundary"]
+    assert client.requested_listing_pages == [0, 1]
+    assert client.requested_topic_ids == [101, 102]
+    assert 103 not in client.requested_topic_ids
+    assert 104 not in client.requested_topic_ids
+    assert 105 not in client.requested_topic_ids
+
+    required_fields = {"title", "forum_url", "original_url", "content", "published_at", "tags"}
+    assert all(required_fields <= post.keys() for post in posts)
+    assert posts[0] == {
+        "title": "In Window",
+        "forum_url": f"{FORUM_BASE_URL}/t/in-window/101",
+        "original_url": "https://github.com/example/project",
+        "content": "첫 번째 실제 본문입니다.\n\n두 번째 실제 본문입니다.",
+        "published_at": "2026-07-15",
+        "tags": ["llm", "research"],
+    }
+    assert posts[1]["forum_url"] == f"{FORUM_BASE_URL}/t/seven-day-boundary/102"
+    assert posts[1]["published_at"] == "2026-07-08"
+
+
+def test_records_failed_detail_and_continues_with_other_eligible_topics():
+    successful_topic = _topic(201, "Successful Detail", "2026-07-14T12:00:00.000Z")
+    failed_topic = _topic(202, "Failed Detail", "2026-07-13T12:00:00.000Z")
+    client = RecordingForumClient(
+        [_listing([successful_topic, failed_topic])],
+        {
+            201: _detail(SAMPLE_TOPIC_HTML),
+            202: FakeResponse({}, url=f"{FORUM_BASE_URL}/t/202.json", status_code=503),
+        },
+    )
+
+    posts, errors = _fetch_pytorch_kr_forum_posts(
+        client,
+        PUBLICATION_DATE,
+        max_pages=1,
+        request_delay_seconds=0,
+    )
+
+    assert [post["title"] for post in posts] == ["Successful Detail"]
+    assert client.requested_topic_ids == [201, 202]
+    assert len(errors) == 1
+    assert "202" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Public error-as-data wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_public_wrapper_serializes_invalid_date_as_error_envelope():
+    payload = json.loads(search_pytorch_kr_forum("not-a-date"))
+
+    assert isinstance(payload["errors"], list)
+    assert payload["errors"]
+
+
+def test_public_wrapper_serializes_top_level_http_failure(monkeypatch):
+    monkeypatch.setattr(
+        "src.tools.search_tools.httpx.Client",
+        lambda **kwargs: FailingForumClient(),
+    )
+
+    payload = json.loads(search_pytorch_kr_forum(PUBLICATION_DATE))
+
+    assert payload["publication_date"] == PUBLICATION_DATE
+    assert payload["posts"] == []
+    assert isinstance(payload["errors"], list)
+    assert payload["errors"]

--- a/tests/test_pytorch_kr_forum.py
+++ b/tests/test_pytorch_kr_forum.py
@@ -48,6 +48,8 @@ SAMPLE_INELIGIBLE_LINKS_HTML = """\
 <a href="https://discuss.pytorch.kr/signup">가입</a>
 <a href="https://pytorch.kr/">PyTorchKR 홈</a>
 <a href="https://t.me/pytorchkr">텔레그램</a>
+<a href="https://telegram.me/pytorchkr">텔레그램</a>
+<a href="https://web.telegram.org/a/#-1001234567890">텔레그램</a>
 <footer>
   <a href="https://discuss-noti.pytorch.kr/">알림</a>
   <a href="https://www.discourse.org">Powered by Discourse</a>

--- a/tests/test_pytorch_kr_forum.py
+++ b/tests/test_pytorch_kr_forum.py
@@ -53,6 +53,7 @@ SAMPLE_INELIGIBLE_LINKS_HTML = """\
 <footer>
   <a href="https://discuss-noti.pytorch.kr/">알림</a>
   <a href="https://www.discourse.org">Powered by Discourse</a>
+  <a href="https://example.com/footer-source">외부 원문처럼 보이는 푸터 링크</a>
 </footer>
 """
 

--- a/tests/test_pytorch_kr_forum.py
+++ b/tests/test_pytorch_kr_forum.py
@@ -1,9 +1,11 @@
 """Red tests defining the PyTorch-KR Discourse research-source adapter."""
 
 import json
+from datetime import datetime, timedelta
 from urllib.parse import parse_qs, urlparse
 
 import httpx
+import pytest
 
 from src.tools.search_tools import (
     _extract_pytorch_kr_post_fields,
@@ -55,6 +57,12 @@ SAMPLE_INELIGIBLE_LINKS_HTML = """\
   <a href="https://www.discourse.org">Powered by Discourse</a>
   <a href="https://example.com/footer-source">외부 원문처럼 보이는 푸터 링크</a>
 </footer>
+"""
+
+SAMPLE_FOOTER_ONEBOX_HTML = """\
+<p>외부 원문이 없는 게시글입니다.</p>
+<p>토론은 포럼에서 이어집니다.</p>
+<footer><aside data-onebox-src="https://github.com/example/footer-link"></aside></footer>
 """
 
 
@@ -187,6 +195,14 @@ def test_rejects_internal_media_anchor_signup_home_telegram_and_footer_links():
     assert original_url == forum_url
 
 
+def test_rejects_onebox_link_from_forum_footer():
+    forum_url = f"{FORUM_BASE_URL}/t/example/105"
+
+    _, original_url = _extract_pytorch_kr_post_fields(SAMPLE_FOOTER_ONEBOX_HTML, forum_url)
+
+    assert original_url == forum_url
+
+
 # ---------------------------------------------------------------------------
 # Paginated Discourse collection and error isolation
 # ---------------------------------------------------------------------------
@@ -295,3 +311,20 @@ def test_public_wrapper_serializes_top_level_http_failure(monkeypatch):
     assert payload["posts"] == []
     assert isinstance(payload["errors"], list)
     assert payload["errors"]
+
+
+@pytest.mark.integration
+def test_live_pytorch_kr_forum_returns_structured_posts():
+    publication_date = datetime.now().strftime("%Y-%m-%d")
+    earliest_date = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
+
+    payload = json.loads(search_pytorch_kr_forum(publication_date))
+
+    assert payload["publication_date"] == publication_date
+    assert payload["posts"]
+    post = payload["posts"][0]
+    assert post["title"]
+    assert post["forum_url"].startswith("https://discuss.pytorch.kr/t/")
+    assert earliest_date <= post["published_at"] <= publication_date
+    assert post["content"]
+    assert post["original_url"].startswith("http")

--- a/tests/test_pytorch_kr_forum.py
+++ b/tests/test_pytorch_kr_forum.py
@@ -48,6 +48,7 @@ SAMPLE_INELIGIBLE_LINKS_HTML = """\
 <a href="https://discuss.pytorch.kr/uploads/default/original/1X/image.png">업로드 이미지</a>
 <a href="#reply-1">댓글 앵커</a>
 <a href="https://discuss.pytorch.kr/signup">가입</a>
+<a href="https://external.example/signup">외부 서비스 가입</a>
 <a href="https://pytorch.kr/">PyTorchKR 홈</a>
 <a href="https://t.me/pytorchkr">텔레그램</a>
 <a href="https://telegram.me/pytorchkr">텔레그램</a>
@@ -59,10 +60,16 @@ SAMPLE_INELIGIBLE_LINKS_HTML = """\
 </footer>
 """
 
+SAMPLE_DIV_FOOTER_LINK_HTML = """\
+<p>외부 원문이 없는 게시글입니다.</p>
+<p>토론은 포럼에서 이어집니다.</p>
+<div class="footer"><a href="https://external.example/footer-source">외부 원문처럼 보이는 푸터 링크</a></div>
+"""
+
 SAMPLE_FOOTER_ONEBOX_HTML = """\
 <p>외부 원문이 없는 게시글입니다.</p>
 <p>토론은 포럼에서 이어집니다.</p>
-<footer><aside data-onebox-src="https://github.com/example/footer-link"></aside></footer>
+<div class="footer"><aside data-onebox-src="https://github.com/example/footer-link"></aside></div>
 """
 
 
@@ -195,8 +202,16 @@ def test_rejects_internal_media_anchor_signup_home_telegram_and_footer_links():
     assert original_url == forum_url
 
 
-def test_rejects_onebox_link_from_forum_footer():
+def test_rejects_regular_external_anchor_from_div_footer():
     forum_url = f"{FORUM_BASE_URL}/t/example/105"
+
+    _, original_url = _extract_pytorch_kr_post_fields(SAMPLE_DIV_FOOTER_LINK_HTML, forum_url)
+
+    assert original_url == forum_url
+
+
+def test_rejects_onebox_link_from_div_footer():
+    forum_url = f"{FORUM_BASE_URL}/t/example/106"
 
     _, original_url = _extract_pytorch_kr_post_fields(SAMPLE_FOOTER_ONEBOX_HTML, forum_url)
 

--- a/tests/test_research_collector.py
+++ b/tests/test_research_collector.py
@@ -28,6 +28,7 @@ EXPECTED_CATEGORIES = {
     "study_resources",
     "real_world_usecases",
     "official_blogs",
+    "pytorch_kr_community",
 }
 
 
@@ -90,9 +91,13 @@ def test_run_searches_collects_items_and_tags_category(monkeypatch):
             "total_count": 1,
         })
 
+    def fake_search_pytorch_kr_forum(publication_date):
+        return json.dumps({"publication_date": publication_date, "posts": []})
+
     monkeypatch.setattr("src.tools.research_collector.search_ai_news", fake_search_ai_news)
     monkeypatch.setattr("src.tools.research_collector.search_hackernews", fake_search_hackernews)
     monkeypatch.setattr("src.tools.research_collector.fetch_official_blog_posts", fake_fetch_official_blog_posts)
+    monkeypatch.setattr("src.tools.research_collector.search_pytorch_kr_forum", fake_search_pytorch_kr_forum)
 
     plan = _build_query_plan("2026-06-17")
     raw_results, errors = _run_searches(plan, "2026-06-17")
@@ -114,6 +119,7 @@ def test_run_searches_captures_errors_without_raising(monkeypatch):
     monkeypatch.setattr("src.tools.research_collector.search_ai_news", boom)
     monkeypatch.setattr("src.tools.research_collector.search_hackernews", boom)
     monkeypatch.setattr("src.tools.research_collector.fetch_official_blog_posts", boom)
+    monkeypatch.setattr("src.tools.research_collector.search_pytorch_kr_forum", boom)
 
     plan = _build_query_plan("2026-06-17")
     raw_results, errors = _run_searches(plan, "2026-06-17")
@@ -397,6 +403,9 @@ def test_collect_weekly_research_core_returns_envelope(monkeypatch, tmp_path):
             "total_count": 0,
         })
 
+    def fake_search_pytorch_kr_forum(publication_date):
+        return json.dumps({"publication_date": publication_date, "posts": []})
+
     def fake_fetch_article_content(url):
         return json.dumps({"url": url, "domain": "example.com", "title": "AI News",
                             "description": "", "content": "full content " * 50})
@@ -411,6 +420,7 @@ def test_collect_weekly_research_core_returns_envelope(monkeypatch, tmp_path):
     monkeypatch.setattr("src.tools.research_collector.search_ai_news", fake_search_ai_news)
     monkeypatch.setattr("src.tools.research_collector.search_hackernews", fake_search_hackernews)
     monkeypatch.setattr("src.tools.research_collector.fetch_official_blog_posts", fake_fetch_official_blog_posts)
+    monkeypatch.setattr("src.tools.research_collector.search_pytorch_kr_forum", fake_search_pytorch_kr_forum)
     monkeypatch.setattr("src.tools.research_collector.fetch_article_content", fake_fetch_article_content)
 
     result = _collect_weekly_research_core("2026-06-17", summarizer=fake_summarizer)
@@ -434,6 +444,7 @@ def test_collect_weekly_research_wrapper_returns_valid_json_on_search_failure(mo
     monkeypatch.setattr("src.tools.research_collector.search_ai_news", boom)
     monkeypatch.setattr("src.tools.research_collector.search_hackernews", boom)
     monkeypatch.setattr("src.tools.research_collector.fetch_official_blog_posts", boom)
+    monkeypatch.setattr("src.tools.research_collector.search_pytorch_kr_forum", boom)
 
     output = collect_weekly_research("2026-06-17")
     parsed = json.loads(output)


### PR DESCRIPTION
## Summary
- Add PyTorch-KR forum as a primary research source for Korean AI/LLM news
- Collect recent forum posts and integrate into research pipeline
- Add edge case handling and fallback logic for forum source processing

## Test plan
- [x] Forum source edge cases covered
- [x] Forum original URLs fallback working
- [x] Forum links properly filtered (reject Telegram, ignore footers)
- [x] PyTorch-KR candidates integrated into research results
- [x] Forum sources surface in research reports

🤖 Generated with Claude Code